### PR TITLE
Support 'period' query filter

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -671,8 +671,7 @@ export function gooseRestRouter<T>(
       return res.sendStatus(403);
     }
 
-    let query = {};
-
+    let query: any = {};
     for (const queryParam of Object.keys(options.defaultQueryParams ?? [])) {
       query[queryParam] = (options.defaultQueryParams ?? {})[queryParam];
     }
@@ -723,6 +722,10 @@ export function gooseRestRouter<T>(
     let limit = options.defaultLimit ?? 100;
     if (Number(req.query.limit)) {
       limit = Math.min(Number(req.query.limit), options.maxLimit ?? 500);
+    }
+    if (query.period) {
+      // need to remove 'period' since it isn't part of any schemas but parsed and applied in queryFilter instead
+      delete query.period;
     }
 
     let builtQuery = model.find(query).limit(limit + 1);


### PR DESCRIPTION
Instead of having to calculate dates on the front end, supporting passing in a 'period' param. The logic will be in 'queryFilter' on the backend but we can't have the period passing through as a part of the query to the schema since it isn't actually in the schema.