### PR TITLE
Add Array Operations

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -34,7 +34,14 @@ interface StaffUser extends User {
   department: string;
 }
 
+interface FoodCategory {
+  _id?: string;
+  name: string;
+  show: boolean;
+}
+
 interface Food {
+  id: string;
   name: string;
   calories: number;
   created: Date;
@@ -43,6 +50,8 @@ interface Food {
   source: {
     name: string;
   };
+  tags: string[];
+  categories: FoodCategory[];
 }
 
 const userSchema = new Schema<User>({
@@ -71,7 +80,12 @@ const staffUserSchema = new Schema<StaffUser>({
 });
 const StaffUserModel = UserModel.discriminator("Staff", staffUserSchema);
 
-const schema = new Schema<Food>({
+const foodCategorySchema = new Schema<FoodCategory>({
+  name: String,
+  show: Boolean,
+});
+
+const foodSchema = new Schema<Food>({
   name: String,
   calories: Number,
   created: Date,
@@ -80,9 +94,11 @@ const schema = new Schema<Food>({
     name: String,
   },
   hidden: {type: Boolean, default: false},
+  tags: [String],
+  categories: [foodCategorySchema],
 });
 
-const FoodModel = model<Food>("Food", schema);
+const FoodModel = model<Food>("Food", foodSchema);
 
 interface RequiredField {
   name: string;
@@ -717,15 +733,154 @@ describe("ferns-api", () => {
     });
   });
 
-  let spinach: Food;
-  let apple: Food;
-  let carrots: Food;
-  let pizza: Food;
+  describe("model array operations", function () {
+    let admin: any;
+    let spinach: Food;
+    let apple: Food;
+    let agent: supertest.SuperAgentTest;
+
+    beforeEach(async function () {
+      [admin] = await setupDb();
+
+      [spinach, apple] = await Promise.all([
+        FoodModel.create({
+          name: "Spinach",
+          calories: 1,
+          created: new Date("2021-12-03T00:00:20.000Z"),
+          ownerId: admin._id,
+          hidden: false,
+          source: {
+            name: "Brand",
+          },
+        }),
+        FoodModel.create({
+          name: "Apple",
+          calories: 100,
+          created: new Date("2021-12-03T00:00:30.000Z"),
+          ownerId: admin._id,
+          hidden: false,
+          categories: [
+            {
+              name: "Fruit",
+              show: true,
+            },
+            {
+              name: "Popular",
+              show: false,
+            },
+          ],
+          tags: ["healthy", "cheap"],
+        }),
+      ]);
+
+      app = getBaseServer();
+      setupAuth(app, UserModel as any);
+      app.use(
+        "/food",
+        gooseRestRouter(FoodModel, {
+          permissions: {
+            list: [Permissions.IsAdmin],
+            create: [Permissions.IsAdmin],
+            read: [Permissions.IsAdmin],
+            update: [Permissions.IsAdmin],
+            delete: [Permissions.IsAdmin],
+          },
+          sort: {created: "descending"},
+          queryFields: ["hidden", "calories", "created", "source.name"],
+        })
+      );
+      server = supertest(app);
+      agent = await authAsUser(app, "admin");
+    });
+
+    it("add array sub-schema item", async function () {
+      // Incorrect way, should have "categories" as a top level key.
+      let res = await agent
+        .post(`/food/${apple.id}/categories`)
+        .send({name: "Good Seller", show: false})
+        .expect(400);
+      assert.equal(
+        res.body.title,
+        "Malformed body, array operations should have a single, top level key, got: name,show"
+      );
+
+      res = await agent
+        .post(`/food/${apple.id}/categories`)
+        .send({categories: {name: "Good Seller", show: false}})
+        .expect(200);
+      assert.lengthOf(res.body.data.categories, 3);
+      assert.equal(res.body.data.categories[2].name, "Good Seller");
+
+      res = await agent
+        .post(`/food/${spinach.id}/categories`)
+        .send({categories: {name: "Good Seller", show: false}})
+        .expect(200);
+      assert.lengthOf(res.body.data.categories, 1);
+    });
+
+    it("update array sub-schema item", async function () {
+      let res = await agent
+        .patch(`/food/${apple.id}/categories/xyz`)
+        .send({categories: {name: "Good Seller", show: false}})
+        .expect(404);
+      assert.equal(res.body.title, "Could not find categories/xyz");
+      res = await agent
+        .patch(`/food/${apple.id}/categories/${apple.categories[1]._id}`)
+        .send({categories: {name: "Good Seller", show: false}})
+        .expect(200);
+      assert.lengthOf(res.body.data.categories, 2);
+      assert.equal(res.body.data.categories[1].name, "Good Seller");
+    });
+
+    it("delete array sub-schema item", async function () {
+      let res = await agent.delete(`/food/${apple.id}/categories/xyz`).expect(404);
+      assert.equal(res.body.title, "Could not find categories/xyz");
+      res = await agent
+        .delete(`/food/${apple.id}/categories/${apple.categories[0]._id}`)
+        .expect(200);
+      assert.lengthOf(res.body.data.categories, 1);
+      assert.equal(res.body.data.categories[0].name, "Popular");
+    });
+
+    it("add array item", async function () {
+      let res = await agent.post(`/food/${apple.id}/tags`).send({tags: "popular"}).expect(200);
+      assert.lengthOf(res.body.data.tags, 3);
+      assert.deepEqual(res.body.data.tags, ["healthy", "cheap", "popular"]);
+
+      res = await agent.post(`/food/${spinach.id}/tags`).send({tags: "popular"}).expect(200);
+      assert.deepEqual(res.body.data.tags, ["popular"]);
+    });
+
+    it("update array item", async function () {
+      let res = await agent
+        .patch(`/food/${apple.id}/tags/xyz`)
+        .send({tags: "unhealthy"})
+        .expect(404);
+      assert.equal(res.body.title, "Could not find tags/xyz");
+      res = await agent
+        .patch(`/food/${apple.id}/tags/healthy`)
+        .send({tags: "unhealthy"})
+        .expect(200);
+      assert.deepEqual(res.body.data.tags, ["unhealthy", "cheap"]);
+    });
+
+    it("delete array item", async function () {
+      let res = await agent.delete(`/food/${apple.id}/tags/xyz`).expect(404);
+      assert.equal(res.body.title, "Could not find tags/xyz");
+      res = await agent.delete(`/food/${apple.id}/tags/healthy`).expect(200);
+      assert.deepEqual(res.body.data.tags, ["cheap"]);
+    });
+  });
 
   describe("list options", function () {
     let notAdmin: any;
     let admin: any;
     let agent: supertest.SuperAgentTest;
+
+    let spinach: Food;
+    let apple: Food;
+    let carrots: Food;
+    let pizza: Food;
 
     beforeEach(async function () {
       [admin, notAdmin] = await setupDb();

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, {NextFunction, Request, Response} from "express";
 import jwt from "jsonwebtoken";
 import mongoose, {Document, Model, ObjectId, Schema} from "mongoose";
 import passport from "passport";
@@ -6,7 +6,9 @@ import {Strategy as AnonymousStrategy} from "passport-anonymous";
 import {Strategy as JwtStrategy} from "passport-jwt";
 import {Strategy as LocalStrategy} from "passport-local";
 
+import {APIError, getAPIErrorBody, isAPIError} from "./errors";
 import {logger} from "./logger";
+import {isValidObjectId} from "./utils";
 
 export interface Env {
   NODE_ENV?: string;
@@ -924,5 +926,161 @@ export function gooseRestRouter<T>(
     return res.sendStatus(204);
   });
 
+  async function arrayOperation(
+    req: Request,
+    res: Response,
+    operation: "POST" | "PATCH" | "DELETE"
+  ) {
+    // TODO this is very similar to .patch()
+    const model = getModel(baseModel, req.body, options);
+
+    if (!(await checkPermissions("update", options.permissions.update, req.user))) {
+      throw new APIError({
+        title: `Access to PATCH on ${model.name} denied for ${req.user?.id}`,
+        status: 405,
+      });
+    }
+
+    const doc = await model.findById(req.params.id);
+    // We fail here because we might fetch the document without the __t but we'd be missing all the hooks.
+    if (!doc || (doc.__t && !req.body.__t)) {
+      throw new APIError({
+        title: `Could not find document to PATCH: ${req.params.id}`,
+        status: 404,
+      });
+    }
+
+    if (!(await checkPermissions("update", options.permissions.update, req.user, doc))) {
+      throw new APIError({
+        title: `Patch not allowed for user ${req.user?.id} on doc ${doc._id}`,
+        status: 403,
+      });
+    }
+
+    // We apply the operation *before* the hooks. As far as the callers are concerned, this should
+    // be like PATCHing the field and replacing the whole thing.
+    if (operation !== "DELETE" && req.body[req.params.field] === undefined) {
+      throw new APIError({
+        title: `Malformed body, array operations should have a single, top level key, got: ${Object.keys(
+          req.body
+        ).join(",")}`,
+        status: 400,
+      });
+    }
+
+    const field = req.params.field;
+
+    const array = [...doc[field]];
+    if (operation === "POST") {
+      array.push(req.body[field]);
+    } else if (operation === "PATCH" || operation === "DELETE") {
+      // Check for subschema vs String array:
+      let index;
+      if (isValidObjectId(req.params.itemId)) {
+        index = array.findIndex((x: any) => x.id === req.params.itemId);
+      } else {
+        index = array.findIndex((x: string) => x === req.params.itemId);
+      }
+      if (index === -1) {
+        throw new APIError({
+          title: `Could not find ${field}/${req.params.itemId}`,
+          status: 404,
+        });
+      }
+      if (operation === "PATCH") {
+        array[index] = req.body[field];
+      } else {
+        array.splice(index, 1);
+      }
+    } else {
+      throw new APIError({
+        title: `Invalid array operation: ${operation}`,
+        status: 400,
+      });
+    }
+    let body: Partial<T> | null = {[field]: array} as unknown as Partial<T>;
+
+    try {
+      body = transform(body, "update", req.user) as Partial<T>;
+    } catch (e) {
+      throw new APIError({
+        title: (e as any).message,
+        status: 403,
+      });
+    }
+
+    if (options.preUpdate) {
+      try {
+        body = await options.preUpdate(body, req);
+      } catch (e) {
+        throw new APIError({
+          title: `PATCH Pre Update error on ${req.params.id}: ${(e as any).message}`,
+          status: 400,
+        });
+      }
+      if (body === null) {
+        throw new APIError({
+          title: `PATCH Pre Update on ${req.params.id} returned null`,
+          status: 403,
+        });
+      }
+    }
+
+    // Using .save here runs the risk of a versioning error if you try to make two simultaneous updates. We won't
+    // wind up with corrupted data, just an API error.
+    try {
+      Object.assign(doc, body);
+      await doc.save();
+    } catch (e) {
+      throw new APIError({
+        title: `PATCH Pre Update error on ${req.params.id}: ${(e as any).message}`,
+        status: 400,
+      });
+    }
+
+    if (options.postUpdate) {
+      try {
+        await options.postUpdate(doc, body, req);
+      } catch (e) {
+        throw new APIError({
+          title: `PATCH Post Update error on ${req.params.id}: ${(e as any).message}`,
+          status: 400,
+        });
+      }
+    }
+    return res.json({data: serialize(doc, req.user)});
+  }
+
+  async function arrayPost(req: Request, res: Response) {
+    return arrayOperation(req, res, "POST");
+  }
+
+  async function arrayPatch(req: Request, res: Response) {
+    return arrayOperation(req, res, "PATCH");
+  }
+
+  async function arrayDelete(req: Request, res: Response) {
+    return arrayOperation(req, res, "DELETE");
+  }
+  // Set up routes for managing array fields. Check if there any array fields to add this for.
+  if (Object.values(baseModel.schema.paths).find((config) => config.instance === "Array")) {
+    router.post(`/:id/:field`, authenticateMiddleware(true), asyncHandler(arrayPost));
+    router.patch(`/:id/:field/:itemId`, authenticateMiddleware(true), asyncHandler(arrayPatch));
+    router.delete(`/:id/:field/:itemId`, authenticateMiddleware(true), asyncHandler(arrayDelete));
+    router.use(apiErrorMiddleware);
+  }
+
   return router;
 }
+
+function apiErrorMiddleware(err: Error, req: Request, res: Response, next: NextFunction) {
+  if (isAPIError(err)) {
+    return res.status(err.status).json(getAPIErrorBody(err));
+  }
+  return next(err);
+}
+
+// Since express doesn't handle async routes well, wrap them with this function.
+const asyncHandler = (fn: any) => (req: Request, res: Response, next: NextFunction) => {
+  return Promise.resolve(fn(req, res, next)).catch(next);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./api";
+export * from "./errors";
 export * from "./expressServer";
-export * from "./passport";
 export * from "./logger";
+export * from "./passport";
+export * from "./utils";

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,14 @@
+import {assert} from "chai";
+
+import {isValidObjectId} from "./utils";
+
+describe("utils", function () {
+  it("checks valid ObjectIds", function () {
+    assert.isTrue(isValidObjectId("62c44da0003d9f8ee8cc925c"));
+    assert.isTrue(isValidObjectId("620000000000000000000000"));
+    // Mongoose's builtin "ObjectId.isValid" will falsely say this is an ObjectId.
+    assert.isFalse(isValidObjectId("1234567890ab"));
+    assert.isFalse(isValidObjectId("microsoft123"));
+    assert.isFalse(isValidObjectId("62c44da0003d9f8ee8cc925x"));
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+import {ObjectId} from "mongodb";
+
+// A better version of mongoose's ObjectId.isValid, which falsely will say any 12 character string is valid.
+export function isValidObjectId(id: string): boolean {
+  try {
+    return new ObjectId(id).toString() === id;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
This provides an easy way to operate on arrays items individually
instead of replacing the entire array when you need to modify one item.
It will be automatically added to any route that has a model with an
array field.

Add APIErrors to return JSONAPI errors
This gives a standardized error format and logs errors more easily.

Add function to determine if a string is an ObjectId

Closes #61 