### PR TITLE
Export plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export * from "./expressServer";
 export * from "./logger";
 export * from "./passport";
 export * from "./permissions";
+export * from "./plugins";
 export * from "./transformers";
 export * from "./utils";


### PR DESCRIPTION
When moving code around, I forgot to add plugins to index.ts so they'd be
exported outside the package.