### PR TITLE
Add findOneOrThrows plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/chai": "^4.2.22",
+    "@types/chai-as-promised": "^7.1.5",
     "@types/cors": "^2.8.12",
     "@types/cron": "^2.0.0",
     "@types/express": "^4.17.8",
@@ -69,6 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^8.15.0",
     "eslint-config-ferns": "^0.4.0",
     "eslint-config-prettier": "^8.5.0",

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -1,0 +1,57 @@
+import chai, {assert} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {model, Schema} from "mongoose";
+chai.use(chaiAsPromised);
+
+import {findOneOrThrow} from "./plugins";
+import {setupDb} from "./tests";
+
+interface Stuff {
+  _id: string;
+  name: string;
+  ownerId: string;
+}
+
+const stuffSchema = new Schema<Stuff>({
+  name: String,
+  ownerId: String,
+});
+
+stuffSchema.plugin(findOneOrThrow);
+
+const stuffModel = model<Stuff>("Stuff", stuffSchema);
+
+describe("findOneOrThrow", function () {
+  let things: any;
+
+  beforeEach(async function () {
+    await stuffModel.deleteMany({});
+    await setupDb();
+
+    [things] = await Promise.all([
+      stuffModel.create({
+        name: "Things",
+        ownerId: "123",
+      }),
+      stuffModel.create({
+        name: "StuffNThings",
+        ownerId: "123",
+      }),
+    ]);
+  });
+
+  it("returns null with no matches.", async function () {
+    const result = await (stuffModel as any).findOneOrThrow({name: "OtherStuff"});
+    assert.isNull(result);
+  });
+
+  it("returns a single match", async function () {
+    const result = await (stuffModel as any).findOneOrThrow({name: "Things"});
+    assert.equal(result._id.toString(), things._id.toString());
+  });
+
+  it("throws error with two matches.", async function () {
+    const fn = () => (stuffModel as any).findOneOrThrow({ownerId: "123"});
+    await assert.isRejected(fn(), "findOne query returned multiple documents");
+  });
+});

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,5 +1,7 @@
 import jwt from "jsonwebtoken";
-import {Schema} from "mongoose";
+import {FilterQuery, Schema} from "mongoose";
+
+import {APIError} from "./errors";
 
 export function tokenPlugin(schema: Schema) {
   schema.add({token: {type: String, index: true}});
@@ -85,4 +87,28 @@ export function createdUpdatedPlugin(schema: Schema) {
 
 export function firebaseJWTPlugin(schema: Schema) {
   schema.add({firebaseId: {type: String, index: true}});
+}
+
+/**
+ * This adds a static method `Model.findOneOrThrow` to the schema. This should replace `Model.findOne` in most instances.
+ * `Model.findOne` should only be used with a unique index, but that's not apparent from the docs. Otherwise you can wind
+ * up with a random document that matches the query. The returns either null if no document matches, the actual
+ * document, or throws an exception if multiple are found.
+ * @param schema Mongoose Schema
+ */
+export function findOneOrThrow<T>(schema: Schema) {
+  schema.statics.findOneOrThrow = async function (query: FilterQuery<T>): Promise<T | null> {
+    const results = await this.find(query);
+    if (results.length === 0) {
+      return null;
+    } else if (results.length > 1) {
+      throw new APIError({
+        status: 500,
+        title: "findOne query returned multiple documents",
+        detail: `query: ${JSON.stringify(query)}`,
+      });
+    } else {
+      return results[0];
+    }
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,7 +917,14 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/chai@^4.2.22":
+"@types/chai-as-promised@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.2.22":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
   integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
@@ -1610,6 +1617,13 @@ caniuse-lite@^1.0.30001332:
   version "1.0.30001341"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
   integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
 
 chai@^4.3.4:
   version "4.3.6"


### PR DESCRIPTION
.findOne should generally be considered unsafe, unless using a unique
index, but that's not very apparent from the docs. Replacing all usages
of .findOne with .findOneOrThrows should prevent inadvertant and silent
issues while maintaining a good dev experience, rather than writing a
similar if/else if/else statement every time you want to find one doc.