### PR TITLE
Populate object reads like we populate list queries

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -321,7 +321,20 @@ export function fernsRouter<T>(
       return res.sendStatus(405);
     }
 
-    const data = await model.findById(req.params.id);
+    let builtQuery = model.findById(req.params.id);
+    for (const populatePath of options.populatePaths ?? []) {
+      builtQuery = builtQuery.populate(populatePath);
+    }
+
+    let data;
+    try {
+      data = await builtQuery.exec();
+    } catch (e) {
+      throw new APIError({
+        status: 500,
+        title: `GET failed on ${req.params.id}: : ${(e as any).stack}`,
+      });
+    }
 
     if (!data) {
       return res.sendStatus(404);


### PR DESCRIPTION
It's a little weird when we read a single object and it's not populated, whereas it is when you list the same item.