### PR TITLE
Fix potential JWT token leak

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -550,6 +550,38 @@ describe("ferns-api", () => {
     });
   });
 
+  describe("plugins", function () {
+    let agent: supertest.SuperAgentTest;
+
+    beforeEach(async function () {
+      await setupDb();
+      app = getBaseServer();
+      setupAuth(app, UserModel as any);
+      app.use(
+        "/users",
+        fernsRouter(UserModel, {
+          permissions: {
+            list: [Permissions.IsAny],
+            create: [Permissions.IsAny],
+            read: [Permissions.IsAny],
+            update: [Permissions.IsAny],
+            delete: [Permissions.IsAny],
+          },
+        })
+      );
+      server = supertest(app);
+      agent = await authAsUser(app, "notAdmin");
+    });
+
+    it("check that security fields are filtered", async function () {
+      const res = await agent.get("/users").expect(200);
+      assert.isDefined(res.body.data[0].email);
+      assert.isUndefined(res.body.data[0].token);
+      assert.isUndefined(res.body.data[0].hash);
+      assert.isUndefined(res.body.data[0].salt);
+    });
+  });
+
   describe("discriminator", function () {
     let superUser: mongoose.Document<SuperUser>;
     let staffUser: mongoose.Document<StaffUser>;

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -4,7 +4,8 @@ import {FilterQuery, Schema} from "mongoose";
 import {APIError} from "./errors";
 
 export function tokenPlugin(schema: Schema) {
-  schema.add({token: {type: String, index: true}});
+  // Set "select" to false so the token is never leaked.
+  schema.add({token: {type: String, index: true, select: false}});
   schema.pre("save", function (next) {
     // Add created when creating the object
     if (!this.token) {


### PR DESCRIPTION
The token plugin wasn't setting "select: false" to default Mongoose to
not selecting that field. If the plugin was used on users and then you
return the result of `User.find()`, the tokens would be readable. This
follows the same pattern passport uses with hash and salt fields.