### PR TITLE
Capture more errors with Sentry

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 // https://jsonapi.org/format/#errors
+import * as Sentry from "@sentry/node";
 import {NextFunction, Request, Response} from "express";
 import {Schema} from "mongoose";
 
@@ -158,6 +159,7 @@ export function getAPIErrorBody(error: APIError): {[id: string]: any} {
 }
 
 export function apiErrorMiddleware(err: Error, req: Request, res: Response, next: NextFunction) {
+  Sentry.captureException(err);
   if (isAPIError(err)) {
     return res.status(err.status).json(getAPIErrorBody(err));
   }


### PR DESCRIPTION
By default, it is only capturing 5xx errors, which aren't as common as all the APIErrors which tend to be 4xx.