### PR TITLE
Make email logins case insensitive

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -686,29 +686,34 @@ describe("ferns-api", () => {
 
     it("gets all users", async function () {
       const res = await agent.get("/users").expect(200);
-      assert.lengthOf(res.body.data, 4);
+      assert.lengthOf(res.body.data, 5);
 
       const data = sortBy(res.body.data, ["email"]);
 
-      assert.equal(data[0].email, "admin@example.com");
+      assert.equal(data[0].email, "admin+other@example.com");
       assert.isUndefined(data[0].department);
       assert.isUndefined(data[0].supertitle);
       assert.isUndefined(data[0].__t);
 
-      assert.equal(data[1].email, "notAdmin@example.com");
+      assert.equal(data[1].email, "admin@example.com");
       assert.isUndefined(data[1].department);
       assert.isUndefined(data[1].supertitle);
       assert.isUndefined(data[1].__t);
 
-      assert.equal(data[2].email, "staff@example.com");
-      assert.equal(data[2].department, "Accounting");
+      assert.equal(data[2].email, "notAdmin@example.com");
+      assert.isUndefined(data[2].department);
       assert.isUndefined(data[2].supertitle);
-      assert.equal(data[2].__t, "Staff");
+      assert.isUndefined(data[2].__t);
 
-      assert.equal(data[3].email, "superuser@example.com");
-      assert.isUndefined(data[3].department);
-      assert.equal(data[3].superTitle, "Super Man");
-      assert.equal(data[3].__t, "SuperUser");
+      assert.equal(data[3].email, "staff@example.com");
+      assert.equal(data[3].department, "Accounting");
+      assert.isUndefined(data[3].supertitle);
+      assert.equal(data[3].__t, "Staff");
+
+      assert.equal(data[4].email, "superuser@example.com");
+      assert.isUndefined(data[4].department);
+      assert.equal(data[4].superTitle, "Super Man");
+      assert.equal(data[4].__t, "SuperUser");
     });
 
     it("gets a discriminated user", async function () {

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -160,6 +160,24 @@ describe("auth tests", function () {
     assert.deepEqual(res.body, {message: "User Not Found"});
   });
 
+  it("case insensitive email", async function () {
+    const agent = supertest.agent(app);
+    const res = await agent
+      .post("/auth/login")
+      .send({email: "ADMIN@example.com", password: "securePassword"})
+      .expect(200);
+    assert.isDefined(res.body.data.token);
+  });
+
+  it("case insensitive email with emails with symbols", async function () {
+    const agent = supertest.agent(app);
+    const res = await agent
+      .post("/auth/login")
+      .send({email: "ADMIN+other@example.com", password: "otherPassword"})
+      .expect(200);
+    assert.isDefined(res.body.data.token);
+  });
+
   it("completes token login e2e", async function () {
     const agent = supertest.agent(app);
     const res = await agent

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,7 @@ import {Strategy as JwtStrategy} from "passport-jwt";
 import {Strategy as LocalStrategy} from "passport-local";
 
 import {logger} from "./logger";
+import {UserModel} from "./tests";
 
 export interface User {
   _id: ObjectId | string;
@@ -28,6 +29,7 @@ export interface UserModel extends Model<User> {
 
   // Allows additional setup during signup. This will be passed the rest of req.body from the signup
   deserializeUser(): any;
+  findByUsername(username: string, findOpts: any): any;
 }
 
 export function authenticateMiddleware(anonymous = false) {
@@ -97,7 +99,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
       async (email, password, done) => {
         try {
           // TODO this causes a login error in authenticate()??
-          const user = await userModel.findOne({email}).select("+token").exec();
+          const user = await userModel.findByUsername(email, {selectTokenField: true});
           if (!user) {
             logger.warn(`Could not find login user for ${email}`);
             return done(null, false, {message: "User Not Found"});

--- a/src/passport.ts
+++ b/src/passport.ts
@@ -22,6 +22,7 @@
 import crypto from "crypto";
 // @ts-ignore
 import generaterr from "generaterr";
+import escapeRegExp from "lodash/escapeRegExp";
 import {Schema} from "mongoose";
 import {Strategy as LocalStrategy} from "passport-local";
 // @ts-ignore
@@ -448,7 +449,7 @@ export const passportLocalMongoose = function (schema: Schema, opts: Partial<Opt
 
     findOpts = findOpts || {};
     findOpts.selectHashSaltFields = !!findOpts.selectHashSaltFields;
-
+    findOpts.selectTokenField = !!findOpts.selectTokenField;
     // if specified, convert the username to lowercase
     if (username !== undefined && options.usernameLowerCase) {
       username = username.toLowerCase();
@@ -459,7 +460,7 @@ export const passportLocalMongoose = function (schema: Schema, opts: Partial<Opt
     for (let i = 0; i < options.usernameQueryFields.length; i++) {
       const parameter = {};
       parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive
-        ? new RegExp(`^${username}$`, "i")
+        ? new RegExp(`^${escapeRegExp(username)}$`, "i")
         : username;
       queryOrParameters.push(parameter);
     }
@@ -468,6 +469,9 @@ export const passportLocalMongoose = function (schema: Schema, opts: Partial<Opt
 
     if (findOpts.selectHashSaltFields) {
       query.select(`+${options.hashField} +${options.saltField}`);
+    }
+    if (findOpts.selectTokenField) {
+      query.select("+token");
     }
 
     if (options.selectFields) {


### PR DESCRIPTION
The previous PR didn't fix case insensitive emails because the email login strategy searched for the email directly instead of using passports `findByUsername()`, where the insensitive search was added. Also escape the regex created for case insensitivity, because plus symbols caused errors.