### PR TITLE
Ability to disable signup endpoint and fix up tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   verbose: true,
   maxWorkers: 1,
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  setupFiles: ["<rootDir>/jestSetupFile.js"],
+  setupFilesAfterEnv: ["<rootDir>/src/tests/jestSetup.ts"],
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
@@ -13,6 +13,7 @@ module.exports = {
 
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   testPathIgnorePatterns: ["<rootDir>/web", "<rootDir>/dist"],
+  testLocationInResults: true,
   // moduleNameMapper: {
   //   "firebase-admin": "<rootDir>/__mocks__/firebaseMock.ts",
   // },

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -31,6 +31,7 @@ describe("ferns-api", () => {
     let agent: supertest.SuperAgentTest;
 
     beforeEach(async function () {
+      process.env.REFRESH_TOKEN_SECRET = "testsecret1234";
       await setupDb();
       app = getBaseServer();
       setupAuth(app, UserModel as any);

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -31,7 +31,6 @@ describe("ferns-api", () => {
     let agent: supertest.SuperAgentTest;
 
     beforeEach(async function () {
-      process.env.REFRESH_TOKEN_SECRET = "testsecret1234";
       await setupDb();
       app = getBaseServer();
       setupAuth(app, UserModel as any);

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -7,7 +7,6 @@ import {setupAuth} from "./auth";
 import {Permissions} from "./permissions";
 import {Food, FoodModel, getBaseServer, setupDb, UserModel} from "./tests";
 import {AdminOwnerTransformer} from "./transformers";
-import {timeout} from "./utils";
 
 describe("auth tests", function () {
   let app: express.Application;
@@ -240,7 +239,7 @@ describe("auth tests", function () {
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
-    await timeout(1000);
+
     assert.deepEqual(res.body, {message: "Password or username is incorrect"});
     let user = await UserModel.findById(admin._id);
     assert.equal((user as any)?.attempts, 1);
@@ -248,7 +247,7 @@ describe("auth tests", function () {
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
-    await timeout(1000);
+
     assert.deepEqual(res.body, {message: "Password or username is incorrect"});
     user = await UserModel.findById(admin._id);
     assert.equal((user as any)?.attempts, 2);
@@ -256,7 +255,7 @@ describe("auth tests", function () {
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
-    await timeout(1000);
+
     assert.deepEqual(res.body, {message: "Account locked due to too many failed login attempts"});
     user = await UserModel.findById(admin._id);
     assert.equal((user as any)?.attempts, 3);
@@ -266,7 +265,7 @@ describe("auth tests", function () {
       .post("/auth/login")
       .send({email: "admin@example.com", password: "securePassword"})
       .expect(401);
-    await timeout(1000);
+
     assert.deepEqual(res.body, {message: "Account locked due to too many failed login attempts"});
     user = await UserModel.findById(admin._id);
     // Not incremented

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -15,8 +15,6 @@ describe("auth tests", function () {
   let notAdmin: any;
 
   beforeEach(async function () {
-    process.env.REFRESH_TOKEN_SECRET = "testsecret1234";
-
     [admin, notAdmin] = await setupDb();
 
     await Promise.all([

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -232,16 +232,19 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
     return res.status(401).json({message: "Invalid refresh token"});
   });
 
-  router.post(
-    "/signup",
-    passport.authenticate("signup", {session: false, failWithError: true}),
-    async function (req: any, res: any) {
-      const tokens = await generateTokens(req.user);
-      return res.json({
-        data: {userId: req.user._id, token: tokens.token, refreshToken: tokens.refreshToken},
-      });
-    }
-  );
+  const signupDisabled = process.env.SIGNUP_DISABLED === "true";
+  if (!signupDisabled) {
+    router.post(
+      "/signup",
+      passport.authenticate("signup", {session: false, failWithError: true}),
+      async function (req: any, res: any) {
+        const tokens = await generateTokens(req.user);
+        return res.json({
+          data: {userId: req.user._id, token: tokens.token, refreshToken: tokens.refreshToken},
+        });
+      }
+    );
+  }
 
   router.get("/me", authenticateMiddleware(), async (req, res) => {
     if (!req.user?.id) {

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -34,6 +34,27 @@ export function setupErrorLogging() {
   }
 }
 
+export function setupEnvironment(): void {
+  if (!process.env.TOKEN_ISSUER) {
+    throw new Error("TOKEN_ISSUER must be set in env.");
+  }
+  if (!process.env.TOKEN_SECRET) {
+    throw new Error("TOKEN_SECRET must be set.");
+  }
+  if (!process.env.REFRESH_TOKEN_SECRET) {
+    logger.warn("REFRESH_TOKEN_SECRET must be set.");
+  }
+  if (!process.env.SESSION_SECRET) {
+    throw new Error("SESSION_SECRET must be set.");
+  }
+  if (!process.env.TOKEN_EXPIRES_IN) {
+    logger.warn("TOKEN_EXPIRES_IN is not set so using default.");
+  }
+  if (!process.env.REFRESH_TOKEN_EXPIRES_IN) {
+    logger.warn("REFRESH_TOKEN_EXPIRES_IN not set so using default.");
+  }
+}
+
 export type AddRoutes = (router: Router) => void;
 
 const logRequestsFinished = function (req: any, res: any, startTime: [number, number]) {
@@ -124,9 +145,7 @@ function initializeRoutes(
   addRoutes: AddRoutes,
   options: InitializeRoutesOptions = {}
 ) {
-  if (!process.env.SESSION_SECRET && process.env.NODE_ENV === "production") {
-    throw new Error("You must provide a SESSION_SECRET in env.");
-  }
+  setupEnvironment();
 
   const app = express();
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -54,6 +54,8 @@ userSchema.plugin(passportLocalMongoose, {
   attemptsField: "attempts",
   maxAttempts: 3,
   usernameCaseInsensitive: true,
+  interval: process.env.NODE_ENV === "test" ? 1 : 100,
+  maxInterval: process.env.NODE_ENV === "test" ? 1 : 300000,
 });
 // userSchema.plugin(tokenPlugin);
 userSchema.plugin(createdUpdatedPlugin);

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,0 +1,1 @@
+export * from "./jestSetup";

--- a/src/tests/jestSetup.ts
+++ b/src/tests/jestSetup.ts
@@ -1,0 +1,9 @@
+import {setupEnvironment} from "../expressServer";
+
+beforeEach(function () {
+  process.env.TOKEN_SECRET = "secret";
+  process.env.TOKEN_ISSUER = "ferns-api.test";
+  process.env.SESSION_SECRET = "sessionSecret";
+  process.env.REFRESH_TOKEN_SECRET = "refreshTokenSecret";
+  setupEnvironment();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,
@@ -22,7 +22,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,
     // "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
@@ -41,7 +41,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": ["src/express.d.ts"] /* Type declaration files to be included in compilation. */,
+    // "types": ["types/*.d.ts"] /* Type declaration files to be included in compilation. */,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
The `/auth/signup` endpoint is completely unauthenticated and sometimes there is a requirement to not allow external entities to sign up for an app. This will allow us to turn off this endpoint and only allow sign up done by an already authenticated user (Like an admin creating a user account on their behalf).

To avoid making this a breaking change, it'll default to enabled.