### PR TITLE
Add rejection handler to catch rejections of all levels

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,6 +31,7 @@ function printf(timestamp = false) {
 // Setup a default console logger.
 export const logger = winston.createLogger({
   level: "debug",
+  exitOnError: false,
   transports: [
     new winston.transports.Console({
       debugStdout: true,
@@ -47,7 +48,7 @@ export const logger = winston.createLogger({
   rejectionHandlers: [
     new winston.transports.Console({
       debugStdout: true,
-      level: "debug",
+      level: "error",
       format: winston.format.combine(winston.format.colorize(), winston.format.simple()),
     }),
   ],


### PR DESCRIPTION
https://github.com/FlourishHealth/flourish/issues/451

I _believe_ that this is being caused by some higher level logs (error, warn, etc.) that are going uncaught when rejected. The suggestion for this fix was found here: https://github.com/googleapis/nodejs-logging/issues/1185#issuecomment-1023610571