### PR TITLE
Enforce only a single string when Logging

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -195,7 +195,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
         return next(err);
       }
       if (!user) {
-        logger.warn(`Invalid login: $info}`);
+        logger.warn(`Invalid login: ${info}`);
         return res.status(401).json({message: info?.message});
       }
       const tokens = await generateTokens(user);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -53,7 +53,7 @@ export async function signupUser(
       try {
         await user.postCreate(body);
       } catch (error: any) {
-        logger.error("Error in user.postCreate", error);
+        logger.error(`Error in user.postCreate: ${error}`);
         throw new APIError({title: error.message});
       }
     }
@@ -168,7 +168,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
         try {
           user = await userModel.findById(jwtPayload.id);
         } catch (e) {
-          logger.warn("[jwt] Error finding user from id", e);
+          logger.warn(`[jwt] Error finding user from id: ${e}`);
           return done(e, false);
         }
         if (user) {
@@ -191,11 +191,11 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
   router.post("/login", async function (req, res, next) {
     passport.authenticate("local", {session: true}, async (err: any, user: any, info: any) => {
       if (err) {
-        logger.error("Error logging in:", err);
+        logger.error(`Error logging in: ${err}`);
         return next(err);
       }
       if (!user) {
-        logger.warn("Invalid login:", info);
+        logger.warn(`Invalid login: $info}`);
         return res.status(401).json({message: info?.message});
       }
       const tokens = await generateTokens(user);
@@ -219,7 +219,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
     try {
       decoded = jwt.verify(req.body.refreshToken, refreshTokenSecretOrKey) as JwtPayload;
     } catch (e: any) {
-      logger.error("Error refreshing token:", e);
+      logger.error(`Error refreshing token: ${e}`);
       return res.status(401).json({message: e?.message});
     }
     if (decoded && decoded.id) {

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -204,7 +204,7 @@ function initializeRoutes(
   app.use(apiErrorMiddleware);
 
   app.use(function onError(err: any, _req: any, res: any, _next: any) {
-    logger.error("Fallthrough error", err);
+    logger.error(`Fallthrough error: ${err}`);
     Sentry.captureException(err);
     res.statusCode = 500;
     res.end(`${res.sentry}\n`);
@@ -243,7 +243,7 @@ export function setupServer(options: SetupServerOptions) {
       addMiddleware: options.addMiddleware,
     });
   } catch (e) {
-    logger.error("Error initializing routes", e);
+    logger.error(`Error initializing routes: ${e}`);
     throw e;
   }
 
@@ -296,8 +296,8 @@ export async function sendToSlack(text: string, channel = "bots") {
       text,
       channel,
     });
-  } catch (e) {
-    logger.error("Error posting to slack", (e as any).text);
+  } catch (e: any) {
+    logger.error(`Error posting to slack: ${e.text}`);
   }
 }
 

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -75,17 +75,21 @@ const logRequestsFinished = function (req: any, res: any, startTime: [number, nu
 
   logger.debug(`${req.method} -> ${req.originalUrl} ${res.statusCode} ${`${diffInMs}ms`}`);
   if (diffInMs > SLOW_READ_MAX && req.method === "GET") {
-    logger.warn("Slow GET request", {
-      requestTime: diffInMs,
-      pathName,
-      url: req.originalUrl,
-    });
+    logger.warn(
+      `Slow GET request, ${JSON.stringify({
+        requestTime: diffInMs,
+        pathName,
+        url: req.originalUrl,
+      })}`
+    );
   } else if (diffInMs > SLOW_WRITE_MAX) {
-    logger.warn("Slow write request", {
-      requestTime: diffInMs,
-      pathName,
-      url: req.originalUrl,
-    });
+    logger.warn(
+      `Slow write request ${JSON.stringify({
+        requestTime: diffInMs,
+        pathName,
+        url: req.originalUrl,
+      })}`
+    );
   }
 };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,7 +29,7 @@ function printf(timestamp = false) {
 }
 
 // Setup a default console logger.
-export const logger = winston.createLogger({
+export const winstonLogger = winston.createLogger({
   level: "debug",
   transports: [
     new winston.transports.Console({
@@ -53,6 +53,13 @@ export const logger = winston.createLogger({
   ],
 });
 
+export const logger = {
+  debug: (msg: string) => winstonLogger.debug(msg),
+  info: (msg: string) => winstonLogger.info(msg),
+  warn: (msg: string) => winstonLogger.warn(msg),
+  error: (msg: string) => winstonLogger.error(msg),
+};
+
 export interface LoggingOptions {
   level?: "debug" | "info" | "warn" | "error";
   transports?: winston.transport[];
@@ -64,14 +71,14 @@ export interface LoggingOptions {
 }
 
 export function setupLogging(options?: LoggingOptions) {
-  logger.clear();
+  winstonLogger.clear();
   if (!options?.disableConsoleLogging) {
     const formats: any[] = [winston.format.simple()];
     if (!options?.disableConsoleColors) {
       formats.push(winston.format.colorize());
     }
     formats.push(winston.format.printf(printf(options?.showConsoleTimestamps)));
-    logger.add(
+    winstonLogger.add(
       new winston.transports.Console({
         debugStdout: !options?.level || options?.level === "debug",
         level: options?.level ?? "debug",
@@ -98,7 +105,7 @@ export function setupLogging(options?: LoggingOptions) {
       options: {mode: 0o600},
     };
 
-    logger.add(
+    winstonLogger.add(
       new winston.transports.Stream({
         ...FILE_LOG_DEFAULTS,
         level: "error",
@@ -108,7 +115,7 @@ export function setupLogging(options?: LoggingOptions) {
       })
     );
 
-    logger.add(
+    winstonLogger.add(
       new winston.transports.Stream({
         ...FILE_LOG_DEFAULTS,
         level: "info",
@@ -117,7 +124,7 @@ export function setupLogging(options?: LoggingOptions) {
       })
     );
     if (!options?.level || options?.level === "debug") {
-      logger.add(
+      winstonLogger.add(
         new winston.transports.Stream({
           ...FILE_LOG_DEFAULTS,
           level: "debug",
@@ -130,7 +137,7 @@ export function setupLogging(options?: LoggingOptions) {
 
   if (options?.transports) {
     for (const transport of options.transports) {
-      logger.add(transport);
+      winstonLogger.add(transport);
     }
   }
 


### PR DESCRIPTION
Logging full JS objects becomes quite problematic, especially when using things like Google's StackDriver.

This is a breaking change, since all logging that passes multiple args won't compile. We're also changing what's exported as `logger` from a full winston logger to a wrapper with a few methods exposed. If you need to update the winston logger, that is exported as `winstonLogger` now.