### PR TITLE
APIError for Unauthorized

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,7 +36,11 @@ export function authenticateMiddleware(anonymous = false) {
   if (anonymous) {
     strategies.push("anonymous");
   }
-  return passport.authenticate(strategies, {session: false, failureMessage: true});
+  return passport.authenticate(strategies, {
+    session: false,
+    failureMessage: true,
+    failWithError: true,
+  });
 }
 
 export async function signupUser(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -158,6 +158,18 @@ export function getAPIErrorBody(error: APIError): {[id: string]: any} {
   return errorData;
 }
 
+export function apiUnauthorizedMiddleware(
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  if (err.message.includes("Unauthorized")) {
+    return next(new APIError({title: err.message, status: 401}));
+  }
+  return next();
+}
+
 export function apiErrorMiddleware(err: Error, req: Request, res: Response, next: NextFunction) {
   if (isAPIError(err)) {
     Sentry.captureException(err);

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -10,7 +10,7 @@ import onFinished from "on-finished";
 import passport from "passport";
 
 import {setupAuth, UserModel as UserMongooseModel} from "./auth";
-import {apiErrorMiddleware} from "./errors";
+import {apiErrorMiddleware, apiUnauthorizedMiddleware} from "./errors";
 import {logger, LoggingOptions, setupLogging} from "./logger";
 
 const SLOW_READ_MAX = 200;
@@ -205,6 +205,7 @@ function initializeRoutes(
   app.use(Sentry.Handlers.errorHandler());
 
   // Catch any thrown APIErrors and return them in an OpenAPI compatible format
+  app.use(apiUnauthorizedMiddleware);
   app.use(apiErrorMiddleware);
 
   app.use(function onError(err: any, _req: any, res: any, _next: any) {


### PR DESCRIPTION
Right now when we hit an API that is unauthorized (like jwt expired) it just sends 'Unauthorized' in the body which causes parsing issues since its not valid json. This makes sure even our 401's are formatted as an 'APIError' so it's valid json.