### PR TITLE
Send Unauthorized without triggering fallthru error handler

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -165,15 +165,18 @@ export function apiUnauthorizedMiddleware(
   next: NextFunction
 ) {
   if (err.message === "Unauthorized") {
-    next(new APIError({title: err.message, status: 401}));
+    // not using the actual APIError class here because we don't want to log it as an error.
+    res.status(401).json({status: 401, title: "Unauthorized"}).send();
+  } else {
+    next(err);
   }
-  next(err);
 }
 
 export function apiErrorMiddleware(err: Error, req: Request, res: Response, next: NextFunction) {
   if (isAPIError(err)) {
     Sentry.captureException(err);
-    res.status(err.status).json(getAPIErrorBody(err));
+    res.status(err.status).json(getAPIErrorBody(err)).send();
+  } else {
+    next(err);
   }
-  next(err);
 }


### PR DESCRIPTION
- Avoids logging errors
- Avoids the fallthru error handler since it sends the response as soon as it sees the 401
- Sends APIErrors without triggering fallthru