### PR TITLE
Include details in when APIrror is printed

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -77,7 +77,8 @@ export class APIError extends Error {
   meta: {[id: string]: any} | undefined;
 
   constructor(data: APIErrorConstructor) {
-    super(data.title);
+    // Include details in when the error is printed to the console or sent to Sentry.
+    super(`${data.title}${data.detail ? `: ${data.detail}` : ""}`);
     this.name = "APIError";
 
     // eslint-disable-next-line prefer-const


### PR DESCRIPTION
Trying to track down this error, but we aren't getting enough details: https://flourish-health.sentry.io/issues/4115782684/?query=is%3Aunresolved&referrer=issue-stream&stream_index=10