### PR TITLE
Remove deprecated node-setup, use Node 18/20, Mongo 6.0

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-        mongodb-version: ["5.0"]
+        node-version: [16.x, 18.x, 20.x]
+        mongodb-version: ["6.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Start MongoDB

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x]
         mongodb-version: ["6.0"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/api-publish.yml
+++ b/.github/workflows/api-publish.yml
@@ -17,16 +17,16 @@ jobs:
           # "github.event.release.target_commitish" is a global variable and specifies the branch the release targeted
           ref: ${{ github.event.release.target_commitish }}
       # install Node.js
-      - name: Use Node.js 14
-        uses: actions/setup-node@v1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
           # Specifies the registry, this field is required!
           registry-url: https://registry.npmjs.org/
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: 6.0
       - name: Install whole project dependencies
         # if: steps.yarn-cache.outputs.cache-hit != 'true' # I think we want to install every time,
         # but use the cache?


### PR DESCRIPTION
We were getting warnings about node-setup@v1 being deprecated because it uses Node 12.
While we're at it:
Node 14 is in maintence, 16 is only active for another few months, 18 is active, 20 is in testing.