### PR TITLE
Add OpenAPI specifications for FernsRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@sentry/node": "^7.31.1",
     "@sentry/profiling-node": "^0.0.12",
+    "@wesleytodd/openapi": "^0.1.0",
     "axios": "^0.27.2",
     "cors": "^2.8.5",
     "cron": "^2.0.0",
@@ -39,6 +40,7 @@
     "generaterr": "^1.5.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
+    "mongoose-to-swagger": "^1.4.0",
     "on-finished": "^2.3.0",
     "passport": "^0.6.0",
     "passport-anonymous": "^1.0.1",

--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -1,0 +1,1973 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`openApi gets the openapi.json 1`] = `
+Object {
+  "info": Object {
+    "description": "Generated docs from an Express api",
+    "title": "Express Application",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.0",
+  "paths": Object {
+    "/food/": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "query",
+            "name": "page",
+            "schema": Object {
+              "type": "number",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "limit",
+            "schema": Object {
+              "type": "number",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "period",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "data": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "_id": Object {
+                            "type": "string",
+                          },
+                          "calories": Object {
+                            "type": "number",
+                          },
+                          "categories": Object {
+                            "items": Object {
+                              "properties": Object {
+                                "_id": Object {
+                                  "type": "string",
+                                },
+                                "name": Object {
+                                  "type": "string",
+                                },
+                                "show": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "created": Object {
+                            "format": "date-time",
+                            "type": "string",
+                          },
+                          "eatenBy": Object {
+                            "items": Object {
+                              "properties": Object {
+                                "userId": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "required": Array [
+                                "userId",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "hidden": Object {
+                            "type": "boolean",
+                          },
+                          "lastEatenWith": Object {
+                            "additionalProperties": Object {
+                              "format": "date-time",
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                          "ownerId": Object {
+                            "type": "string",
+                          },
+                          "source": Object {
+                            "properties": Object {
+                              "name": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "tags": Object {
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": Array [
+                          "_id",
+                          "created",
+                          "updated",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "limit": Object {
+                      "type": "number",
+                    },
+                    "more": Object {
+                      "type": "boolean",
+                    },
+                    "page": Object {
+                      "type": "number",
+                    },
+                    "total": Object {
+                      "type": "number",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful list",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": Object {
+            "description": "The user must be authenticated",
+          },
+          "403": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+      },
+      "post": Object {
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "_id": Object {
+                    "type": "string",
+                  },
+                  "calories": Object {
+                    "type": "number",
+                  },
+                  "categories": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "_id": Object {
+                          "type": "string",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                        "show": Object {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": Array [],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "created": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "eatenBy": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "userId": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "userId",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "hidden": Object {
+                    "type": "boolean",
+                  },
+                  "lastEatenWith": Object {
+                    "additionalProperties": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "name": Object {
+                    "type": "string",
+                  },
+                  "ownerId": Object {
+                    "type": "string",
+                  },
+                  "source": Object {
+                    "properties": Object {
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "tags": Object {
+                    "items": Object {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": Object {
+          "201": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "_id": Object {
+                      "type": "string",
+                    },
+                    "calories": Object {
+                      "type": "number",
+                    },
+                    "categories": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "_id": Object {
+                            "type": "string",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                          "show": Object {
+                            "type": "boolean",
+                          },
+                        },
+                        "required": Array [],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "created": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                    "eatenBy": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "userId": Object {
+                            "type": "string",
+                          },
+                        },
+                        "required": Array [
+                          "userId",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "hidden": Object {
+                      "type": "boolean",
+                    },
+                    "lastEatenWith": Object {
+                      "additionalProperties": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                    "ownerId": Object {
+                      "type": "string",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "_id",
+                    "created",
+                    "updated",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful create",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": Object {
+            "description": "The user must be authenticated",
+          },
+          "403": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+      },
+    },
+    "/food/{id}": Object {
+      "delete": Object {
+        "parameters": Array [
+          Object {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": Object {
+          "204": Object {
+            "description": "Successful delete",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": Object {
+            "description": "The user must be authenticated",
+          },
+          "403": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+      },
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "_id": Object {
+                      "type": "string",
+                    },
+                    "calories": Object {
+                      "type": "number",
+                    },
+                    "categories": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "_id": Object {
+                            "type": "string",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                          "show": Object {
+                            "type": "boolean",
+                          },
+                        },
+                        "required": Array [],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "created": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                    "eatenBy": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "userId": Object {
+                            "type": "string",
+                          },
+                        },
+                        "required": Array [
+                          "userId",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "hidden": Object {
+                      "type": "boolean",
+                    },
+                    "lastEatenWith": Object {
+                      "additionalProperties": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                    "ownerId": Object {
+                      "type": "string",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "_id",
+                    "created",
+                    "updated",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful read",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": Object {
+            "description": "The user must be authenticated",
+          },
+          "403": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+      },
+      "patch": Object {
+        "parameters": Array [
+          Object {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "_id": Object {
+                    "type": "string",
+                  },
+                  "calories": Object {
+                    "type": "number",
+                  },
+                  "categories": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "_id": Object {
+                          "type": "string",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                        "show": Object {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": Array [],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "created": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "eatenBy": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "userId": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "userId",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "hidden": Object {
+                    "type": "boolean",
+                  },
+                  "lastEatenWith": Object {
+                    "additionalProperties": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "name": Object {
+                    "type": "string",
+                  },
+                  "ownerId": Object {
+                    "type": "string",
+                  },
+                  "source": Object {
+                    "properties": Object {
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "tags": Object {
+                    "items": Object {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "_id": Object {
+                      "type": "string",
+                    },
+                    "calories": Object {
+                      "type": "number",
+                    },
+                    "categories": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "_id": Object {
+                            "type": "string",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                          "show": Object {
+                            "type": "boolean",
+                          },
+                        },
+                        "required": Array [],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "created": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                    "eatenBy": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "userId": Object {
+                            "type": "string",
+                          },
+                        },
+                        "required": Array [
+                          "userId",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "hidden": Object {
+                      "type": "boolean",
+                    },
+                    "lastEatenWith": Object {
+                      "additionalProperties": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                    "ownerId": Object {
+                      "type": "string",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "_id",
+                    "created",
+                    "updated",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful update",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": Object {
+            "description": "The user must be authenticated",
+          },
+          "403": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "description": "An application-specific error code, expressed as a string value.",
+                      "type": "string",
+                    },
+                    "detail": Object {
+                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+                      "type": "string",
+                    },
+                    "id": Object {
+                      "description": "A unique identifier for this particular occurrence of the problem.",
+                      "type": "string",
+                    },
+                    "links": Object {
+                      "properties": Object {
+                        "about": Object {
+                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "meta": Object {
+                      "description": "A meta object containing non-standard meta-information about the error.",
+                      "type": "object",
+                    },
+                    "source": Object {
+                      "properties": Object {
+                        "header": Object {
+                          "description": "A string indicating the name of a single request header which caused the error.",
+                          "type": "string",
+                        },
+                        "parameter": Object {
+                          "description": "A string indicating which URI query parameter caused the error.",
+                          "type": "string",
+                        },
+                        "pointer": Object {
+                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \\"/data\\" for a primary data object, or \\"/data/attributes/title\\" for a specific attribute].",
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "status": Object {
+                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+                      "type": "number",
+                    },
+                    "title": Object {
+                      "description": "The error message",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -14,6 +14,21 @@ Object {
         "parameters": Array [
           Object {
             "in": "query",
+            "name": "_id",
+            "schema": Object {
+              "properties": Object {
+                "$in": Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              },
+              "type": "object",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "page",
             "schema": Object {
               "type": "number",
@@ -86,6 +101,7 @@ Object {
                             "type": "array",
                           },
                           "hidden": Object {
+                            "default": false,
                             "type": "boolean",
                           },
                           "lastEatenWith": Object {
@@ -412,6 +428,9 @@ Object {
             "description": "The user is not allowed to perform this action on any document",
           },
         },
+        "tags": Array [
+          "foods",
+        ],
       },
       "post": Object {
         "requestBody": Object {
@@ -462,6 +481,7 @@ Object {
                     "type": "array",
                   },
                   "hidden": Object {
+                    "default": false,
                     "type": "boolean",
                   },
                   "lastEatenWith": Object {
@@ -547,6 +567,7 @@ Object {
                       "type": "array",
                     },
                     "hidden": Object {
+                      "default": false,
                       "type": "boolean",
                     },
                     "lastEatenWith": Object {
@@ -856,6 +877,9 @@ Object {
             "description": "The user is not allowed to perform this action on any document",
           },
         },
+        "tags": Array [
+          "foods",
+        ],
       },
     },
     "/food/{id}": Object {
@@ -1142,6 +1166,9 @@ Object {
             "description": "The user is not allowed to perform this action on any document",
           },
         },
+        "tags": Array [
+          "foods",
+        ],
       },
       "get": Object {
         "parameters": Array [
@@ -1512,6 +1539,9 @@ Object {
             "description": "The user is not allowed to perform this action on any document",
           },
         },
+        "tags": Array [
+          "foods",
+        ],
       },
       "patch": Object {
         "parameters": Array [
@@ -1572,6 +1602,7 @@ Object {
                     "type": "array",
                   },
                   "hidden": Object {
+                    "default": false,
                     "type": "boolean",
                   },
                   "lastEatenWith": Object {
@@ -1657,6 +1688,7 @@ Object {
                       "type": "array",
                     },
                     "hidden": Object {
+                      "default": false,
                       "type": "boolean",
                     },
                     "lastEatenWith": Object {
@@ -1966,6 +1998,9 @@ Object {
             "description": "The user is not allowed to perform this action on any document",
           },
         },
+        "tags": Array [
+          "foods",
+        ],
       },
     },
   },

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -269,14 +269,17 @@ describe("ferns-api", () => {
         })
       );
 
-      const resList = await agent.get("/food").expect(200);
+      let resList = await agent.get("/food").expect(200);
 
-      const resApple = resList.body.data.find((f: Food) => f._id === apple._id.toString());
+      let resApple = resList.body.data.find((f: Food) => f._id === apple._id.toString());
       const resOne = await agent.get(`/food/${spinach?._id}`).expect(200);
-
       assert.equal(resApple.name, "Bravery");
-
       assert.equal(resOne.body.data.name, "Popeye's meal");
+
+      // Ensure we support both trailing slash and not.
+      resList = await agent.get("/food/").expect(200);
+      resApple = resList.body.data.find((f: Food) => f._id === apple._id.toString());
+      assert.equal(resApple.name, "Bravery");
     });
   });
 

--- a/src/openApi.test.ts
+++ b/src/openApi.test.ts
@@ -1,0 +1,48 @@
+import express, {Router} from "express";
+import supertest from "supertest";
+
+import {fernsRouter, FernsRouterOptions} from "./api";
+import {addAuthRoutes, setupAuth} from "./auth";
+import {setupServer} from "./expressServer";
+import {Permissions} from "./permissions";
+import {FoodModel, UserModel} from "./tests";
+
+function addRoutes(router: Router, options?: Partial<FernsRouterOptions<any>>): void {
+  router.use(
+    "/food",
+    fernsRouter(FoodModel as any, {
+      ...options,
+      allowAnonymous: true,
+      permissions: {
+        list: [Permissions.IsAny],
+        create: [Permissions.IsAny],
+        read: [Permissions.IsAny],
+        update: [Permissions.IsAny],
+        delete: [Permissions.IsAny],
+      },
+    })
+  );
+}
+
+describe("openApi", function () {
+  let server: supertest.SuperTest<supertest.Test>;
+  let app: express.Application;
+  beforeEach(async function () {
+    process.env.REFRESH_TOKEN_SECRET = "testsecret1234";
+
+    app = setupServer({addRoutes, userModel: UserModel as any, skipListen: true});
+    setupAuth(app, UserModel as any);
+    addAuthRoutes(app, UserModel as any);
+  });
+
+  it("gets the openapi.json", async function () {
+    server = supertest(app);
+    const res = await server.get("/openapi.json").expect(200);
+    expect(res.body).toMatchSnapshot();
+  });
+
+  it("gets the swagger ui", async function () {
+    server = supertest(app);
+    await server.get("/swagger/").expect(200);
+  });
+});

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -1,0 +1,361 @@
+import merge from "lodash/merge";
+import {Model} from "mongoose";
+import m2s from "mongoose-to-swagger";
+
+import {FernsRouterOptions} from "./api";
+import {logger} from "./logger";
+
+const noop = (_a, _b, next) => next();
+
+const apiErrorContent = {
+  "application/json": {
+    schema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "The error message",
+        },
+        status: {
+          type: "number",
+          description:
+            "The HTTP status code applicable to this problem, expressed as a string value.",
+        },
+        id: {
+          type: "string",
+          description: "A unique identifier for this particular occurrence of the problem.",
+        },
+        links: {
+          type: "object",
+          properties: {
+            about: {
+              type: "string",
+              description:
+                "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+            },
+            type: {
+              type: "string",
+              description:
+                "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+            },
+          },
+        },
+        code: {
+          type: "string",
+          description: "An application-specific error code, expressed as a string value.",
+        },
+        detail: {
+          type: "string",
+          description:
+            "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+        },
+        source: {
+          type: "object",
+          properties: {
+            pointer: {
+              type: "string",
+              description:
+                'A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].',
+            },
+            parameter: {
+              type: "string",
+              description: "A string indicating which URI query parameter caused the error.",
+            },
+            header: {
+              type: "string",
+              description:
+                "A string indicating the name of a single request header which caused the error.",
+            },
+          },
+        },
+        meta: {
+          type: "object",
+          description: "A meta object containing non-standard meta-information about the error.",
+        },
+      },
+    },
+  },
+};
+
+// Default error responses
+const defaultErrorResponses = {
+  400: {
+    description: "Bad request",
+    content: apiErrorContent,
+  },
+  401: {
+    description: "The user must be authenticated",
+  },
+  403: {
+    description: "The user is not allowed to perform this action on this document",
+    content: apiErrorContent,
+  },
+  404: {
+    description: "Document not found",
+    content: apiErrorContent,
+  },
+  405: {
+    description: "The user is not allowed to perform this action on any document",
+    content: apiErrorContent,
+  },
+};
+
+export function getOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsRouterOptions<T>>) {
+  if (!options.openApi?.path) {
+    // Just log this once rather than for each middleware.
+    logger.debug("No options.openApi provided, skipping *OpenApiMiddleware");
+    return noop;
+  }
+
+  if (options.permissions?.read?.length === 0) {
+    return noop;
+  }
+
+  const modelSwagger = m2s(model, {props: ["required", "enum"]});
+
+  return options.openApi.path(
+    merge(
+      {
+        responses: {
+          200: {
+            description: "Successful read",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: [...(modelSwagger.required ?? []), "_id", "created", "updated"],
+                  properties: modelSwagger.properties,
+                },
+              },
+            },
+          },
+          ...defaultErrorResponses,
+        },
+      },
+      options.openApiOverwrite?.get ?? {}
+    )
+  );
+}
+
+export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsRouterOptions<T>>) {
+  if (!options.openApi?.path) {
+    return noop;
+  }
+
+  if (options.permissions?.list?.length === 0) {
+    return noop;
+  }
+
+  const modelSwagger = m2s(model);
+
+  // TODO: handle permissions
+  // TODO: handle populate
+  // TODO: handle whitelist/transform
+
+  const modelQueryParams = options.queryFields?.map((field) => {
+    return {
+      name: field,
+      in: "query",
+      schema: modelSwagger.properties[field],
+    };
+  });
+
+  return options.openApi.path(
+    merge(
+      {
+        requests: {
+          parameters: [
+            ...(modelQueryParams ?? []),
+            // pagination
+            {
+              name: "page",
+              in: "query",
+              schema: {
+                type: "number",
+              },
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: {
+                type: "number",
+              },
+            },
+            // special param for period, like "1d"
+            {
+              name: "period",
+              in: "query",
+              schema: {
+                type: "string",
+              },
+            },
+          ],
+        },
+        responses: {
+          200: {
+            description: "Successful list",
+
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        required: [...(modelSwagger.required ?? []), "_id", "created", "updated"],
+                        properties: modelSwagger.properties,
+                      },
+                    },
+                    more: {
+                      type: "boolean",
+                    },
+                    page: {
+                      type: "number",
+                    },
+                    limit: {
+                      type: "number",
+                    },
+                    total: {
+                      type: "number",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          ...defaultErrorResponses,
+        },
+      },
+      options.openApiOverwrite?.list ?? {}
+    )
+  );
+}
+
+export function createOpenApiMiddleware<T>(
+  model: Model<T>,
+  options: Partial<FernsRouterOptions<T>>
+) {
+  if (!options.openApi?.path) {
+    return noop;
+  }
+
+  if (options.permissions?.create?.length === 0) {
+    return noop;
+  }
+
+  const modelSwagger = m2s(model);
+
+  return options.openApi.path(
+    merge(
+      {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: modelSwagger.required,
+                properties: modelSwagger.properties,
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Successful create",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: [...(modelSwagger.required ?? []), "_id", "created", "updated"],
+                  properties: modelSwagger.properties,
+                },
+              },
+            },
+          },
+          ...defaultErrorResponses,
+        },
+      },
+      options.openApiOverwrite?.create ?? {}
+    )
+  );
+}
+
+export function patchOpenApiMiddleware<T>(
+  model: Model<T>,
+  options: Partial<FernsRouterOptions<T>>
+) {
+  if (!options.openApi?.path) {
+    return noop;
+  }
+
+  if (options.permissions?.update?.length === 0) {
+    return noop;
+  }
+
+  const modelSwagger = m2s(model);
+
+  return options.openApi.path(
+    merge(
+      {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: modelSwagger.required,
+                properties: modelSwagger.properties,
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Successful update",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: [...(modelSwagger.required ?? []), "_id", "created", "updated"],
+                  properties: modelSwagger.properties,
+                },
+              },
+            },
+          },
+          ...defaultErrorResponses,
+        },
+      },
+      options.openApiOverwrite?.update ?? {}
+    )
+  );
+}
+
+export function deleteOpenApiMiddleware<T>(
+  model: Model<T>,
+  options: Partial<FernsRouterOptions<T>>
+) {
+  if (!options.openApi?.path) {
+    return noop;
+  }
+
+  if (options.permissions?.delete?.length === 0) {
+    return noop;
+  }
+
+  return options.openApi.path(
+    merge(
+      {
+        responses: {
+          204: {
+            description: "Successful delete",
+          },
+          ...defaultErrorResponses,
+        },
+      },
+      options.openApiOverwrite?.delete ?? {}
+    )
+  );
+}

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -152,6 +152,7 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
   // TODO: handle populate
   // TODO: handle whitelist/transform
 
+  // Convert fernsRouter queryFields into OpenAPI parameters
   const modelQueryParams = options.queryFields?.map((field) => {
     return {
       name: field,
@@ -163,34 +164,32 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
   return options.openApi.path(
     merge(
       {
-        requests: {
-          parameters: [
-            ...(modelQueryParams ?? []),
-            // pagination
-            {
-              name: "page",
-              in: "query",
-              schema: {
-                type: "number",
-              },
+        parameters: [
+          ...(modelQueryParams ?? []),
+          // pagination
+          {
+            name: "page",
+            in: "query",
+            schema: {
+              type: "number",
             },
-            {
-              name: "limit",
-              in: "query",
-              schema: {
-                type: "number",
-              },
+          },
+          {
+            name: "limit",
+            in: "query",
+            schema: {
+              type: "number",
             },
-            // special param for period, like "1d"
-            {
-              name: "period",
-              in: "query",
-              schema: {
-                type: "string",
-              },
+          },
+          // special param for period, like "1d"
+          {
+            name: "period",
+            in: "query",
+            schema: {
+              type: "string",
             },
-          ],
-        },
+          },
+        ],
         responses: {
           200: {
             description: "Successful list",

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -29,8 +29,8 @@ export function isDeletedPlugin(schema: Schema, defaultValue = false) {
 }
 
 export interface CreatedDeleted {
-  updated: Date;
-  created: Date;
+  updated: {type: Date; required: true};
+  created: {type: Date; required: true};
 }
 
 export function createdUpdatedPlugin(schema: Schema) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,6 +393,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
+"@babel/runtime@^7.17.8":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -504,6 +511,11 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@exodus/schemasafe@^1.0.0-rc.2":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@exodus/schemasafe/-/schemasafe-1.0.1.tgz#e4e2d86ae176b7c96fbff033f3b1a8b1cfd390fb"
+  integrity sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -823,6 +835,32 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@redocly/ajv@^8.11.0":
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-8.11.0.tgz#2fad322888dc0113af026e08fceb3e71aae495ae"
+  integrity sha512-9GWx27t7xWhDIR02PA18nzBdLcKQRgc46xNQvjFkrYk4UOmvKhJ/dawwiX0cCOeetN5LcaaiqQbVOWYK62SGHw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+"@redocly/openapi-core@^1.0.0-beta.104":
+  version "1.0.0-beta.128"
+  resolved "https://registry.yarnpkg.com/@redocly/openapi-core/-/openapi-core-1.0.0-beta.128.tgz#097092d3cf0841c83bd7e12ff2091d7955b3b7d7"
+  integrity sha512-3tubjnSOuC/1QQ8NnOFMTudA4pwbWnVJXB64JYNgiE99cTQS+90wehvQiV71XHQMC9/+rPvt4Ft7GXw75hFoNQ==
+  dependencies:
+    "@redocly/ajv" "^8.11.0"
+    "@types/node" "^14.11.8"
+    colorette "^1.2.0"
+    js-levenshtein "^1.1.6"
+    js-yaml "^4.1.0"
+    lodash.isequal "^4.5.0"
+    minimatch "^5.0.1"
+    node-fetch "^2.6.1"
+    pluralize "^8.0.0"
+    yaml-ast-parser "0.0.43"
+
 "@sentry/core@7.31.1":
   version "7.31.1"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.31.1.tgz#8c48e9c6a24b612eb7f757fdf246ed6b22c26b3b"
@@ -1068,6 +1106,11 @@
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"
 
+"@types/json-schema@^7.0.7":
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -1104,6 +1147,11 @@
   version "17.0.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.33.tgz#3c1879b276dc63e73030bb91165e62a4509cd506"
   integrity sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==
+
+"@types/node@^14.11.8":
+  version "14.18.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.51.tgz#cb90935b89c641201c3d07a595c3e22d1cfaa417"
+  integrity sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==
 
 "@types/node@^18.0.0":
   version "18.0.0"
@@ -1333,6 +1381,21 @@
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
+"@wesleytodd/openapi@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@wesleytodd/openapi/-/openapi-0.1.0.tgz#f1cf6bca78795d57cccf3227774b1cd7359b0ce4"
+  integrity sha512-Lkv561gn4bnRVn7L2ArIpdbr1QFIrE1GMnVxIKcR/MN7wBttlzQcPaqAEzavLv59eC6JkPX4vXc+TiMncH1zNA==
+  dependencies:
+    ajv "^6.10.2"
+    http-errors "^1.7.3"
+    merge-deep "^3.0.2"
+    path-to-regexp "^2.4.0"
+    redoc "^2.0.0-alpha.41"
+    router "^1.3.3"
+    serve-static "^1.13.2"
+    swagger-parser "^6.0.5"
+    swagger-ui-dist "^3.20.2"
+
 abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1380,7 +1443,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1454,10 +1517,20 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+array-flatten@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
+  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
 
 array-includes@^3.1.4:
   version "3.1.5"
@@ -1705,6 +1778,11 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1787,6 +1865,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+classnames@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -1800,6 +1883,31 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+clone-deep@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
+  integrity sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==
+  dependencies:
+    for-own "^0.1.3"
+    is-plain-object "^2.0.1"
+    kind-of "^3.0.2"
+    lazy-cache "^1.0.3"
+    shallow-clone "^0.1.2"
+
+clsx@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -1856,6 +1964,11 @@ color@^3.1.3:
     color-convert "^1.9.3"
     color-string "^1.6.0"
 
+colorette@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
 colorspace@1.1.x:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
@@ -1870,6 +1983,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.7.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 component-emitter@^1.3.0:
   version "1.3.0"
@@ -1925,6 +2043,11 @@ cookiejar@^2.1.4:
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
+core-js@^2.5.7:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
 cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
@@ -1969,6 +2092,11 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+decko@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decko/-/decko-1.2.0.tgz#fd43c735e967b8013306884a56fbe665996b6817"
+  integrity sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -2015,7 +2143,7 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@^1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
@@ -2068,6 +2196,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dompurify@^2.2.8:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
+  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
@@ -2174,6 +2307,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promise@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2436,6 +2574,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+eventemitter3@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2544,7 +2687,7 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.1.1:
+fast-safe-stringify@^2.0.7, fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
@@ -2633,6 +2776,28 @@ follow-redirects@^1.14.9:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+for-in@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+  integrity sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==
+
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
+
+for-own@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  integrity sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==
+  dependencies:
+    for-in "^1.0.1"
+
+foreach@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.6.tgz#87bcc8a1a0e74000ff2bf9802110708cfb02eb6e"
+  integrity sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2641,6 +2806,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format-util@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
+  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
 formidable@^2.1.2:
   version "2.1.2"
@@ -2917,6 +3087,17 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-errors@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -2925,6 +3106,11 @@ http-proxy-agent@^5.0.0:
     "@tootallnate/once" "2"
     agent-base "6"
     debug "4"
+
+http2-client@^1.2.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/http2-client/-/http2-client-1.3.5.tgz#20c9dc909e3cc98284dd20af2432c524086df181"
+  integrity sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==
 
 https-proxy-agent@^5.0.0:
   version "5.0.1"
@@ -3058,6 +3244,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-buffer@^1.0.2, is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -3076,6 +3267,11 @@ is-date-object@^1.0.1:
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
   dependencies:
     has-tostringtag "^1.0.0"
+
+is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -3120,6 +3316,13 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-plain-object@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -3171,6 +3374,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -3572,12 +3780,17 @@ jest@^28.1.1:
     import-local "^3.0.2"
     jest-cli "^28.1.1"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.12.1, js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -3602,10 +3815,31 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-pointer@0.6.2, json-pointer@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.2.tgz#f97bd7550be5e9ea901f8c9264c9d436a22a93cd"
+  integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
+  dependencies:
+    foreach "^2.0.4"
+
+json-schema-ref-parser@^6.0.3:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
+  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.12.1"
+    ono "^4.0.11"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3621,6 +3855,16 @@ jsonc-parser@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
   integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
+
+jsonschema-draft4@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz#f0af2005054f0f0ade7ea2118614b69dc512d865"
+  integrity sha512-sBV3UnQPRiyCTD6uzY/Oao2Yohv6KKgQq7zjPwjFHeR6scg/QSXnzDxdugsGaLQDmFUrUlTbMYdEE+72PizhGA==
+
+jsonschema@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.4.tgz#a46bac5d3506a254465bc548876e267c6d0d6464"
+  integrity sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==
 
 jsonwebtoken@^9.0.0:
   version "9.0.0"
@@ -3667,6 +3911,20 @@ kareem@2.5.1:
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.5.1.tgz#7b8203e11819a8e77a34b3517d3ead206764d15d"
   integrity sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==
 
+kind-of@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  integrity sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==
+  dependencies:
+    is-buffer "^1.0.2"
+
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==
+  dependencies:
+    is-buffer "^1.1.5"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3676,6 +3934,16 @@ kuler@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
+lazy-cache@^0.2.3:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
+  integrity sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==
+
+lazy-cache@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+  integrity sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -3710,10 +3978,15 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.get@^4.4.2:
+lodash.get@^4.0.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
+lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -3823,6 +4096,16 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+mark.js@^8.11.1:
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/mark.js/-/mark.js-8.11.1.tgz#180f1f9ebef8b0e638e4166ad52db879beb2ffc5"
+  integrity sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
+
+marked@^4.0.15:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
 marked@^4.0.16:
   version "4.0.18"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.18.tgz#cd0ac54b2e5610cfb90e8fd46ccaa8292c9ed569"
@@ -3837,6 +4120,15 @@ memory-pager@^1.0.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
   integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
+merge-deep@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.3.tgz#1a2b2ae926da8b2ae93a0ac15d90cd1922766003"
+  integrity sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==
+  dependencies:
+    arr-union "^3.1.0"
+    clone-deep "^0.2.4"
+    kind-of "^3.0.2"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -3980,10 +4272,30 @@ minizlib@^2.1.1, minizlib@^2.1.2:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
+mixin-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  integrity sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==
+  dependencies:
+    for-in "^0.1.3"
+    is-extendable "^0.1.1"
+
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mobx-react-lite@^3.4.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz#3a4c22c30bfaa8b1b2aa48d12b2ba811c0947ab7"
+  integrity sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==
+
+mobx-react@^7.2.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.6.0.tgz#ebf0456728a9bd2e5c24fdcf9b36e285a222a7d6"
+  integrity sha512-+HQUNuh7AoQ9ZnU6c4rvbiVVl+wEkb9WqYsVDzGLng+Dqj1XntHu79PvEWKtSMoMj67vFp/ZPXcElosuJO8ckA==
+  dependencies:
+    mobx-react-lite "^3.4.0"
 
 mongodb-connection-string-url@^2.6.0:
   version "2.6.0"
@@ -4003,6 +4315,11 @@ mongodb@5.1.0:
     socks "^2.7.1"
   optionalDependencies:
     saslprep "^1.0.3"
+
+mongoose-to-swagger@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mongoose-to-swagger/-/mongoose-to-swagger-1.4.0.tgz#30e8b9a9766277f8ec82dbcb69e424ed288168ef"
+  integrity sha512-7O5f2bSVT7euXgMMhlxe4gz6sJW8E3GWHties2FR3B+W41yhW5dpG4RuC7rGL3tKi9nyDN/nkorkbs5v0AHLyg==
 
 mongoose@^7.0.0:
   version "7.0.3"
@@ -4082,10 +4399,24 @@ node-abi@^3.28.0:
   dependencies:
     semver "^7.3.5"
 
+node-fetch-h2@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz#c6188325f9bd3d834020bf0f2d6dc17ced2241ac"
+  integrity sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==
+  dependencies:
+    http2-client "^1.2.5"
+
 node-fetch@^2.6.0:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.1:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -4109,6 +4440,13 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
+node-readfiles@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/node-readfiles/-/node-readfiles-0.2.0.tgz#dbbd4af12134e2e635c245ef93ffcf6f60673a5d"
+  integrity sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==
+  dependencies:
+    es6-promise "^3.2.1"
 
 node-releases@^2.0.3:
   version "2.0.4"
@@ -4143,6 +4481,52 @@ npmlog@^6.0.0:
     console-control-strings "^1.1.0"
     gauge "^4.0.3"
     set-blocking "^2.0.0"
+
+oas-kit-common@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/oas-kit-common/-/oas-kit-common-1.0.8.tgz#6d8cacf6e9097967a4c7ea8bcbcbd77018e1f535"
+  integrity sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==
+  dependencies:
+    fast-safe-stringify "^2.0.7"
+
+oas-linter@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/oas-linter/-/oas-linter-3.2.2.tgz#ab6a33736313490659035ca6802dc4b35d48aa1e"
+  integrity sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==
+  dependencies:
+    "@exodus/schemasafe" "^1.0.0-rc.2"
+    should "^13.2.1"
+    yaml "^1.10.0"
+
+oas-resolver@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/oas-resolver/-/oas-resolver-2.5.6.tgz#10430569cb7daca56115c915e611ebc5515c561b"
+  integrity sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==
+  dependencies:
+    node-fetch-h2 "^2.3.0"
+    oas-kit-common "^1.0.8"
+    reftools "^1.1.9"
+    yaml "^1.10.0"
+    yargs "^17.0.1"
+
+oas-schema-walker@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz#74c3cd47b70ff8e0b19adada14455b5d3ac38a22"
+  integrity sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==
+
+oas-validator@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/oas-validator/-/oas-validator-5.0.8.tgz#387e90df7cafa2d3ffc83b5fb976052b87e73c28"
+  integrity sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    oas-kit-common "^1.0.8"
+    oas-linter "^3.2.2"
+    oas-resolver "^2.5.6"
+    oas-schema-walker "^1.1.5"
+    reftools "^1.1.9"
+    should "^13.2.1"
+    yaml "^1.10.0"
 
 object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
@@ -4236,6 +4620,30 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+ono@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
+  integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
+  dependencies:
+    format-util "^1.0.3"
+
+openapi-sampler@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/openapi-sampler/-/openapi-sampler-1.3.1.tgz#eebb2a1048f830cc277398bc8022b415f887e859"
+  integrity sha512-Ert9mvc2tLPmmInwSyGZS+v4Ogu9/YoZuq9oP3EdUklg2cad6+IGndP9yqJJwbgdXwZibiq5fpv6vYujchdJFg==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    json-pointer "0.6.2"
+
+openapi-schema-validation@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz#895c29021be02e000f71c51f859da52118eb1e21"
+  integrity sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==
+  dependencies:
+    jsonschema "1.2.4"
+    jsonschema-draft4 "^1.0.0"
+    swagger-schema-official "2.0.0-bab6bed"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -4361,6 +4769,11 @@ passport@^0.6.0:
     pause "0.0.1"
     utils-merge "^1.0.1"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -4398,6 +4811,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -4412,6 +4830,11 @@ pause@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
+
+perfect-scrollbar@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
+  integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -4434,6 +4857,18 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+polished@^4.1.3:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
+  integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4462,6 +4897,11 @@ pretty-format@^28.0.0, pretty-format@^28.1.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+prismjs@^1.27.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -4488,7 +4928,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.5.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4554,6 +4994,14 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-tabs@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.2.3.tgz#ccbb3e1241ad3f601047305c75db661239977f2f"
+  integrity sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==
+  dependencies:
+    clsx "^1.1.0"
+    prop-types "^15.5.0"
+
 readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -4571,6 +5019,44 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+redoc@^2.0.0-alpha.41:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0.tgz#8b3047ca75b84d31558c6c92da7f84affef35c3e"
+  integrity sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==
+  dependencies:
+    "@redocly/openapi-core" "^1.0.0-beta.104"
+    classnames "^2.3.1"
+    decko "^1.2.0"
+    dompurify "^2.2.8"
+    eventemitter3 "^4.0.7"
+    json-pointer "^0.6.2"
+    lunr "^2.3.9"
+    mark.js "^8.11.1"
+    marked "^4.0.15"
+    mobx-react "^7.2.0"
+    openapi-sampler "^1.3.0"
+    path-browserify "^1.0.1"
+    perfect-scrollbar "^1.5.5"
+    polished "^4.1.3"
+    prismjs "^1.27.0"
+    prop-types "^15.7.2"
+    react-tabs "^3.2.2"
+    slugify "~1.4.7"
+    stickyfill "^1.1.1"
+    style-loader "^3.3.1"
+    swagger2openapi "^7.0.6"
+    url-template "^2.0.8"
+
+reftools@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/reftools/-/reftools-1.1.9.tgz#e16e19f662ccd4648605312c06d34e5da3a2b77e"
+  integrity sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regexp.prototype.flags@^1.4.1:
   version "1.4.3"
@@ -4590,6 +5076,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -4646,6 +5137,19 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+router@^1.3.3:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/router/-/router-1.3.8.tgz#1509614ae1fbc67139a728481c54b057ecfb04bf"
+  integrity sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==
+  dependencies:
+    array-flatten "3.0.0"
+    debug "2.6.9"
+    methods "~1.1.2"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    setprototypeof "1.2.0"
+    utils-merge "1.0.1"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -4717,7 +5221,7 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serve-static@1.15.0:
+serve-static@1.15.0, serve-static@^1.13.2:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
   integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
@@ -4736,6 +5240,16 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+shallow-clone@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-0.1.2.tgz#5909e874ba77106d73ac414cfec1ffca87d97060"
+  integrity sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^2.0.1"
+    lazy-cache "^0.2.3"
+    mixin-object "^2.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -4757,6 +5271,50 @@ shiki@^0.10.1:
     jsonc-parser "^3.0.0"
     vscode-oniguruma "^1.6.1"
     vscode-textmate "5.2.0"
+
+should-equal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-2.0.0.tgz#6072cf83047360867e68e98b09d71143d04ee0c3"
+  integrity sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==
+  dependencies:
+    should-type "^1.4.0"
+
+should-format@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/should-format/-/should-format-3.0.3.tgz#9bfc8f74fa39205c53d38c34d717303e277124f1"
+  integrity sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==
+  dependencies:
+    should-type "^1.3.0"
+    should-type-adaptors "^1.0.1"
+
+should-type-adaptors@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz#401e7f33b5533033944d5cd8bf2b65027792e27a"
+  integrity sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==
+  dependencies:
+    should-type "^1.3.0"
+    should-util "^1.0.0"
+
+should-type@^1.3.0, should-type@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/should-type/-/should-type-1.4.0.tgz#0756d8ce846dfd09843a6947719dfa0d4cff5cf3"
+  integrity sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==
+
+should-util@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.1.tgz#fb0d71338f532a3a149213639e2d32cbea8bcb28"
+  integrity sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==
+
+should@^13.2.1:
+  version "13.2.3"
+  resolved "https://registry.yarnpkg.com/should/-/should-13.2.3.tgz#96d8e5acf3e97b49d89b51feaa5ae8d07ef58f10"
+  integrity sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==
+  dependencies:
+    should-equal "^2.0.0"
+    should-format "^3.0.3"
+    should-type "^1.4.0"
+    should-type-adaptors "^1.0.1"
+    should-util "^1.0.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -4805,6 +5363,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slugify@~1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.7.tgz#e42359d505afd84a44513280868e31202a79a628"
+  integrity sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==
 
 smart-buffer@^4.2.0:
   version "4.2.0"
@@ -4884,6 +5447,16 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+"statuses@>= 1.5.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+stickyfill@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stickyfill/-/stickyfill-1.1.1.tgz#39413fee9d025c74a7e59ceecb23784cc0f17f02"
+  integrity sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -4968,6 +5541,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-loader@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
+  integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
+
 superagent@^8.0.5:
   version "8.0.9"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.0.9.tgz#2c6fda6fadb40516515f93e9098c0eb1602e0535"
@@ -5025,6 +5603,51 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+swagger-methods@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/swagger-methods/-/swagger-methods-1.0.8.tgz#8baf37ee861d3c72ff7b2faad6d74c60b336e2ed"
+  integrity sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA==
+
+swagger-parser@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-6.0.5.tgz#9475971c7b2c7b0402e1cdee35182fe78b90673b"
+  integrity sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    json-schema-ref-parser "^6.0.3"
+    ono "^4.0.11"
+    openapi-schema-validation "^0.4.2"
+    swagger-methods "^1.0.8"
+    swagger-schema-official "2.0.0-bab6bed"
+    z-schema "^3.24.2"
+
+swagger-schema-official@2.0.0-bab6bed:
+  version "2.0.0-bab6bed"
+  resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
+  integrity sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==
+
+swagger-ui-dist@^3.20.2:
+  version "3.52.5"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz#9aa8101a2be751f5145195b9e048bc21b12fac60"
+  integrity sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw==
+
+swagger2openapi@^7.0.6:
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/swagger2openapi/-/swagger2openapi-7.0.8.tgz#12c88d5de776cb1cbba758994930f40ad0afac59"
+  integrity sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    node-fetch "^2.6.1"
+    node-fetch-h2 "^2.3.0"
+    node-readfiles "^0.2.0"
+    oas-kit-common "^1.0.8"
+    oas-resolver "^2.5.6"
+    oas-schema-walker "^1.1.5"
+    oas-validator "^5.0.8"
+    reftools "^1.1.9"
+    yaml "^1.10.0"
+    yargs "^17.0.1"
 
 tar@^6.1.11, tar@^6.1.2:
   version "6.1.13"
@@ -5226,6 +5849,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5249,6 +5877,11 @@ v8-to-istanbul@^9.0.0:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+validator@^10.0.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
+  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -5386,10 +6019,38 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-ast-parser@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
+  integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
 yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.0.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^17.3.1:
   version "17.5.1"
@@ -5403,3 +6064,15 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+z-schema@^3.24.2:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.25.1.tgz#7e14663be2b96003d938a56f644fb8561643fb7e"
+  integrity sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==
+  dependencies:
+    core-js "^2.5.7"
+    lodash.get "^4.0.0"
+    lodash.isequal "^4.0.0"
+    validator "^10.0.0"
+  optionalDependencies:
+    commander "^2.7.1"


### PR DESCRIPTION
When using expressServer, it will automatically configure a /swagger route to explore the API.

Update APIError to more closely match JSONAPI's error doc (which it is based on).

Update example so it's more usable for testing.

Breaking change: changes the call signature for `addRoutes` to allow passing the openApi 
in `options`. Also, passing the `options` may let downstream `addRoutes` be smarter,
so win-win.