### PR TITLE
Handle population in OpenAPI

### DIFF
--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -101,7 +101,6 @@ Object {
                             "type": "array",
                           },
                           "hidden": Object {
-                            "default": false,
                             "type": "boolean",
                           },
                           "lastEatenWith": Object {
@@ -115,7 +114,50 @@ Object {
                             "type": "string",
                           },
                           "ownerId": Object {
-                            "type": "string",
+                            "properties": Object {
+                              "__t": Object {
+                                "type": "string",
+                              },
+                              "_id": Object {
+                                "type": "string",
+                              },
+                              "admin": Object {
+                                "default": false,
+                                "type": "boolean",
+                              },
+                              "age": Object {
+                                "type": "number",
+                              },
+                              "attempts": Object {
+                                "default": 0,
+                                "type": "number",
+                              },
+                              "created": Object {
+                                "format": "date-time",
+                                "type": "string",
+                              },
+                              "email": Object {
+                                "type": "string",
+                              },
+                              "hash": Object {
+                                "type": "string",
+                              },
+                              "last": Object {
+                                "format": "date-time",
+                                "type": "string",
+                              },
+                              "salt": Object {
+                                "type": "string",
+                              },
+                              "updated": Object {
+                                "format": "date-time",
+                                "type": "string",
+                              },
+                              "username": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
                           },
                           "source": Object {
                             "properties": Object {
@@ -481,7 +523,6 @@ Object {
                     "type": "array",
                   },
                   "hidden": Object {
-                    "default": false,
                     "type": "boolean",
                   },
                   "lastEatenWith": Object {
@@ -495,7 +536,50 @@ Object {
                     "type": "string",
                   },
                   "ownerId": Object {
-                    "type": "string",
+                    "properties": Object {
+                      "__t": Object {
+                        "type": "string",
+                      },
+                      "_id": Object {
+                        "type": "string",
+                      },
+                      "admin": Object {
+                        "default": false,
+                        "type": "boolean",
+                      },
+                      "age": Object {
+                        "type": "number",
+                      },
+                      "attempts": Object {
+                        "default": 0,
+                        "type": "number",
+                      },
+                      "created": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "email": Object {
+                        "type": "string",
+                      },
+                      "hash": Object {
+                        "type": "string",
+                      },
+                      "last": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "salt": Object {
+                        "type": "string",
+                      },
+                      "updated": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "username": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
                   },
                   "source": Object {
                     "properties": Object {
@@ -567,7 +651,6 @@ Object {
                       "type": "array",
                     },
                     "hidden": Object {
-                      "default": false,
                       "type": "boolean",
                     },
                     "lastEatenWith": Object {
@@ -581,7 +664,50 @@ Object {
                       "type": "string",
                     },
                     "ownerId": Object {
-                      "type": "string",
+                      "properties": Object {
+                        "__t": Object {
+                          "type": "string",
+                        },
+                        "_id": Object {
+                          "type": "string",
+                        },
+                        "admin": Object {
+                          "default": false,
+                          "type": "boolean",
+                        },
+                        "age": Object {
+                          "type": "number",
+                        },
+                        "attempts": Object {
+                          "default": 0,
+                          "type": "number",
+                        },
+                        "created": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "email": Object {
+                          "type": "string",
+                        },
+                        "hash": Object {
+                          "type": "string",
+                        },
+                        "last": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "salt": Object {
+                          "type": "string",
+                        },
+                        "updated": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "username": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
                     },
                     "source": Object {
                       "properties": Object {
@@ -1243,7 +1369,50 @@ Object {
                       "type": "string",
                     },
                     "ownerId": Object {
-                      "type": "string",
+                      "properties": Object {
+                        "__t": Object {
+                          "type": "string",
+                        },
+                        "_id": Object {
+                          "type": "string",
+                        },
+                        "admin": Object {
+                          "default": false,
+                          "type": "boolean",
+                        },
+                        "age": Object {
+                          "type": "number",
+                        },
+                        "attempts": Object {
+                          "default": 0,
+                          "type": "number",
+                        },
+                        "created": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "email": Object {
+                          "type": "string",
+                        },
+                        "hash": Object {
+                          "type": "string",
+                        },
+                        "last": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "salt": Object {
+                          "type": "string",
+                        },
+                        "updated": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "username": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
                     },
                     "source": Object {
                       "properties": Object {
@@ -1602,7 +1771,6 @@ Object {
                     "type": "array",
                   },
                   "hidden": Object {
-                    "default": false,
                     "type": "boolean",
                   },
                   "lastEatenWith": Object {
@@ -1616,7 +1784,50 @@ Object {
                     "type": "string",
                   },
                   "ownerId": Object {
-                    "type": "string",
+                    "properties": Object {
+                      "__t": Object {
+                        "type": "string",
+                      },
+                      "_id": Object {
+                        "type": "string",
+                      },
+                      "admin": Object {
+                        "default": false,
+                        "type": "boolean",
+                      },
+                      "age": Object {
+                        "type": "number",
+                      },
+                      "attempts": Object {
+                        "default": 0,
+                        "type": "number",
+                      },
+                      "created": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "email": Object {
+                        "type": "string",
+                      },
+                      "hash": Object {
+                        "type": "string",
+                      },
+                      "last": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "salt": Object {
+                        "type": "string",
+                      },
+                      "updated": Object {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "username": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
                   },
                   "source": Object {
                     "properties": Object {
@@ -1688,7 +1899,6 @@ Object {
                       "type": "array",
                     },
                     "hidden": Object {
-                      "default": false,
                       "type": "boolean",
                     },
                     "lastEatenWith": Object {
@@ -1702,7 +1912,50 @@ Object {
                       "type": "string",
                     },
                     "ownerId": Object {
-                      "type": "string",
+                      "properties": Object {
+                        "__t": Object {
+                          "type": "string",
+                        },
+                        "_id": Object {
+                          "type": "string",
+                        },
+                        "admin": Object {
+                          "default": false,
+                          "type": "boolean",
+                        },
+                        "age": Object {
+                          "type": "number",
+                        },
+                        "attempts": Object {
+                          "default": 0,
+                          "type": "number",
+                        },
+                        "created": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "email": Object {
+                          "type": "string",
+                        },
+                        "hash": Object {
+                          "type": "string",
+                        },
+                        "last": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "salt": Object {
+                          "type": "string",
+                        },
+                        "updated": Object {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "username": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
                     },
                     "source": Object {
                       "properties": Object {

--- a/src/api.ts
+++ b/src/api.ts
@@ -98,8 +98,10 @@ export interface FernsRouterOptions<T> {
    *  to populate based on the user or request, such as app version.
    *    ["ownerId"] // populates the User that matches `ownerId`
    *    ["ownerId.organizationId"] // Nested. Populates the User that matches `ownerId`, as well as their organization.
+   *
+   *  Note: The array of strings style will be correctly handled by OpenAPI, but the function style will not currently.
    * */
-  populatePaths?: string[] | ((req: express.Request) => string[]);
+  populatePaths?: PopulatePaths;
   /** Default limit applied to list queries if not specified by the user. Defaults to 100. */
   defaultLimit?: number;
   /** Maximum query limit the user can request. Defaults to 500, and is the lowest of the limit query, max limit,

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,7 +69,10 @@ export interface FernsRouterOptions<T> {
    * allowed, return `null` from the function and an empty query result will be returned to the client without an error.
    * You can also throw an APIError to be explicit about the issues. You can transform the given query params by
    * returning different values. If the query is acceptable as-is, return `query` as-is. */
-  queryFilter?: (user?: User, query?: Record<string, any>) => Record<string, any> | null;
+  queryFilter?: (
+    user?: User,
+    query?: Record<string, any>
+  ) => Record<string, any> | null | Promise<Record<string, any> | null>;
   /** Transformers allow data to be transformed before actions are executed, and serialized before being returned to
    * the user.
    *

--- a/src/openApi.test.ts
+++ b/src/openApi.test.ts
@@ -13,6 +13,7 @@ function addRoutes(router: Router, options?: Partial<FernsRouterOptions<any>>): 
     fernsRouter(FoodModel as any, {
       ...options,
       allowAnonymous: true,
+      populatePaths: ["ownerId"],
       permissions: {
         list: [Permissions.IsAny],
         create: [Permissions.IsAny],


### PR DESCRIPTION
For APIs with populatePaths set to an array of strings, use those strings to try and guess at the model being populated and add it to the OpenAPI schema. Otherwise the schema would say it was returning a string (for the ObjectID) but really return the whole API, messing up SDKs.

Doesn't currently support the function version of populate paths.