### PR TITLE
Add responseHandler, deprecate postList/postGet

### DIFF
--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -86,6 +86,9 @@ Object {
                             "format": "date-time",
                             "type": "string",
                           },
+                          "description": Object {
+                            "type": "any",
+                          },
                           "eatenBy": Object {
                             "items": Object {
                               "properties": Object {
@@ -99,6 +102,9 @@ Object {
                               "type": "object",
                             },
                             "type": "array",
+                          },
+                          "foo": Object {
+                            "type": "string",
                           },
                           "hidden": Object {
                             "type": "boolean",
@@ -508,6 +514,9 @@ Object {
                     "format": "date-time",
                     "type": "string",
                   },
+                  "description": Object {
+                    "type": "any",
+                  },
                   "eatenBy": Object {
                     "items": Object {
                       "properties": Object {
@@ -521,6 +530,9 @@ Object {
                       "type": "object",
                     },
                     "type": "array",
+                  },
+                  "foo": Object {
+                    "type": "string",
                   },
                   "hidden": Object {
                     "type": "boolean",
@@ -636,6 +648,9 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "description": Object {
+                      "type": "any",
+                    },
                     "eatenBy": Object {
                       "items": Object {
                         "properties": Object {
@@ -649,6 +664,9 @@ Object {
                         "type": "object",
                       },
                       "type": "array",
+                    },
+                    "foo": Object {
+                      "type": "string",
                     },
                     "hidden": Object {
                       "type": "boolean",
@@ -1341,6 +1359,9 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "description": Object {
+                      "type": "any",
+                    },
                     "eatenBy": Object {
                       "items": Object {
                         "properties": Object {
@@ -1354,6 +1375,9 @@ Object {
                         "type": "object",
                       },
                       "type": "array",
+                    },
+                    "foo": Object {
+                      "type": "string",
                     },
                     "hidden": Object {
                       "type": "boolean",
@@ -1756,6 +1780,9 @@ Object {
                     "format": "date-time",
                     "type": "string",
                   },
+                  "description": Object {
+                    "type": "any",
+                  },
                   "eatenBy": Object {
                     "items": Object {
                       "properties": Object {
@@ -1769,6 +1796,9 @@ Object {
                       "type": "object",
                     },
                     "type": "array",
+                  },
+                  "foo": Object {
+                    "type": "string",
                   },
                   "hidden": Object {
                     "type": "boolean",
@@ -1884,6 +1914,9 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "description": Object {
+                      "type": "any",
+                    },
                     "eatenBy": Object {
                       "items": Object {
                         "properties": Object {
@@ -1897,6 +1930,9 @@ Object {
                         "type": "object",
                       },
                       "type": "array",
+                    },
+                    "foo": Object {
+                      "type": "string",
                     },
                     "hidden": Object {
                       "type": "boolean",

--- a/src/api.ts
+++ b/src/api.ts
@@ -132,16 +132,19 @@ export interface FernsRouterOptions<T> {
    * Return null to return a generic 403
    * error. Throw an APIError to return a 400 with specific error information. */
   preDelete?: (value: any, request: express.Request) => T | Promise<T> | null;
-  /** Hook that runs after the object is created but before it is serialized and returned. This is a good spot to
-   * perform dependent changes to other models or performing async tasks, such as sending a push notification.
+  /** Hook that runs after the object is created but before the responseHandler serializes and returned. This is a good
+   * spot to perform dependent changes to other models or performing async tasks/side effects, such as sending a push
+   * notification.
    * Throw an APIError to return a 400 with an error message. */
   postCreate?: (value: T, request: express.Request) => void | Promise<void>;
-  /** Hook that runs after the object is updated but before it is serialized and returned. This is a good spot to
-   * perform dependent changes to other models or performing async tasks, such as sending a push notification.
+  /** Hook that runs after the object is updated but before the responseHandler serializes and returned. This is a good
+   * spot to perform dependent changes to other models or performing async tasks/side effects, such as sending a push
+   * notification.
    * Throw an APIError to return a 400 with an error message. */
   postUpdate?: (value: T, cleanedBody: any, request: express.Request) => void | Promise<void>;
-  /** Hook that runs after the object is created but before it is serialized and returned. This is a good spot to
-   * perform dependent changes to other models or performing async tasks, such as cascading object deletions.
+  /** Hook that runs after the object is deleted. This is a good spot to
+   * perform dependent changes to other models or performing async tasks/side effects, such as cascading object
+   * deletions.
    * Throw an APIError to return a 400 with an error message. */
   postDelete?: (request: express.Request) => void | Promise<void>;
   /** Hook that runs after the object is fetched but before it is serialized.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -40,6 +40,7 @@ export interface APIErrorConstructor {
   };
   // A meta object containing non-standard meta-information about the error.
   meta?: {[id: string]: string};
+  error?: Error;
 }
 
 /**
@@ -78,13 +79,15 @@ export class APIError extends Error {
 
   meta: {[id: string]: any} | undefined;
 
+  error?: Error;
+
   constructor(data: APIErrorConstructor) {
     // Include details in when the error is printed to the console or sent to Sentry.
     super(`${data.title}${data.detail ? `: ${data.detail}` : ""}`);
     this.name = "APIError";
 
     // eslint-disable-next-line prefer-const
-    let {title, id, links, status, code, detail, source, meta, fields} = data;
+    let {title, id, links, status, code, detail, source, meta, fields, error} = data;
 
     if (!status) {
       status = 500;
@@ -105,7 +108,12 @@ export class APIError extends Error {
     if (fields) {
       this.meta.fields = fields;
     }
-    logger.error(`APIError(${status}): ${title} ${detail ? detail : ""}`);
+    this.error = error;
+    logger.error(
+      `APIError(${status}): ${title} ${detail ? detail : ""}${
+        data.error?.stack ? `\n${data.error?.stack}` : ""
+      }`
+    );
   }
 }
 

--- a/src/openApi.test.ts
+++ b/src/openApi.test.ts
@@ -21,6 +21,11 @@ function addRoutes(router: Router, options?: Partial<FernsRouterOptions<any>>): 
         update: [Permissions.IsAny],
         delete: [Permissions.IsAny],
       },
+      openApiExtraModelProperties: {
+        foo: {
+          type: "string",
+        },
+      },
     })
   );
 }

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -109,9 +109,14 @@ const defaultErrorResponses = {
 // Replaces populated properties with the populated schema.
 export function convertModel(
   model: any,
-  populatePaths?: PopulatePaths
+  {
+    populatePaths,
+    extraModelProperties,
+  }: {populatePaths?: PopulatePaths; extraModelProperties?: any} = {}
 ): {properties: any; required: string[]} {
-  const modelSwagger = m2s(model, {props: ["required", "enum"]});
+  const modelSwagger = m2s(model, {
+    props: ["required", "enum"],
+  });
 
   // TODO: this should use OpenAPIs Components to fill in the referenced model instead.
   if (populatePaths && isArray(populatePaths)) {
@@ -130,7 +135,21 @@ export function convertModel(
     });
   }
 
-  return {properties: modelSwagger.properties, required: modelSwagger.required ?? []};
+  // Add virtuals to the modelSwagger property
+  for (const virtual of Object.keys(model.schema.virtuals)) {
+    // This can be added using "omitMongooseInternals" in m2sOptions, so skip it here
+    if (virtual === "id" || virtual === "__v") {
+      continue;
+    }
+    modelSwagger.properties[virtual] = {
+      type: "any",
+    };
+  }
+
+  return {
+    properties: {...modelSwagger.properties, ...extraModelProperties},
+    required: modelSwagger.required ?? [],
+  };
 }
 
 export function getOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsRouterOptions<T>>) {
@@ -144,7 +163,10 @@ export function getOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsR
     return noop;
   }
 
-  const {properties, required} = convertModel(model, options.populatePaths);
+  const {properties, required} = convertModel(model, {
+    populatePaths: options.populatePaths,
+    extraModelProperties: options.openApiExtraModelProperties,
+  });
 
   return options.openApi.path(
     merge(
@@ -240,8 +262,10 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
       })
   );
 
-  const {properties, required} = convertModel(model, options.populatePaths);
-
+  const {properties, required} = convertModel(model, {
+    populatePaths: options.populatePaths,
+    extraModelProperties: options.openApiExtraModelProperties,
+  });
   return options.openApi.path(
     merge(
       {
@@ -327,7 +351,10 @@ export function createOpenApiMiddleware<T>(
     return noop;
   }
 
-  const {properties, required} = convertModel(model, options.populatePaths);
+  const {properties, required} = convertModel(model, {
+    populatePaths: options.populatePaths,
+    extraModelProperties: options.openApiExtraModelProperties,
+  });
   return options.openApi.path(
     merge(
       {
@@ -376,7 +403,10 @@ export function patchOpenApiMiddleware<T>(
     return noop;
   }
 
-  const {properties, required} = convertModel(model, options.populatePaths);
+  const {properties, required} = convertModel(model, {
+    populatePaths: options.populatePaths,
+    extraModelProperties: options.openApiExtraModelProperties,
+  });
   return options.openApi.path(
     merge(
       {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -115,8 +115,12 @@ const foodSchema = new Schema<Food>(
       },
     ],
   },
-  {strict: "throw"}
+  {strict: "throw", toJSON: {virtuals: true}, toObject: {virtuals: true}}
 );
+
+foodSchema.virtual("description").get(function (this: Food) {
+  return `${this.name} has ${this.calories} calories`;
+});
 
 export const FoodModel = model<Food>("Food", foodSchema);
 


### PR DESCRIPTION
Deprecate postList/postGet, responseHandler should manage these. transformers will be removed in a release soon.

Pass error into API error so we can show stack traces. I ran into issues tracking down what function was throwing because we were swallowing the stack trace.

Allow setting extra values via OpenAPI with openApiExtraModelProperties. This is helpful if you add values to objects in the responseHandler so the SDK generates properly and with types.