### PR TITLE
Return JSON for delete endpoints

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -784,7 +784,7 @@ export function fernsRouter<T>(
         }
       }
 
-      return res.sendStatus(204);
+      return res.status(204).json({});
     })
   );
 


### PR DESCRIPTION
RTK Query throws an error when we return an empty response.