### PR TITLE
Add findExactlyOne plugin, allow custom findOneOrThrow errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-unused-imports": "2.0.0",
     "jest": "^28.1.1",
-    "mongoose": "^7.0.0",
+    "mongoose": "^7.6.2",
     "prettier": "^2.6.2",
     "sinon": "^14.0.0",
     "supertest": "^6.1.6",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -53,10 +53,7 @@ export async function signupUser(
   const {email: _email, password: _password, ...bodyRest} = body;
 
   try {
-    console.timeLog(`testsundefined`, "Register start");
-
     const user = await (userModel as any).register({email, ...bodyRest}, password);
-    console.timeLog(`testsundefined`, "Register end");
 
     if (user.postCreate) {
       try {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -53,7 +53,11 @@ export async function signupUser(
   const {email: _email, password: _password, ...bodyRest} = body;
 
   try {
+    console.timeLog(`testsundefined`, "Register start");
+
     const user = await (userModel as any).register({email, ...bodyRest}, password);
+    console.timeLog(`testsundefined`, "Register end");
+
     if (user.postCreate) {
       try {
         await user.postCreate(bodyRest);

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -13,7 +13,7 @@ const m2sOptions = {
   props: ["readOnly", "required", "enum", "default"],
 };
 
-const apiErrorContent = {
+export const apiErrorContent = {
   "application/json": {
     schema: {
       type: "object",
@@ -84,7 +84,7 @@ const apiErrorContent = {
 };
 
 // Default error responses
-const defaultErrorResponses = {
+export const defaultOpenApiErrorResponses = {
   400: {
     description: "Bad request",
     content: apiErrorContent,
@@ -199,7 +199,7 @@ export function getOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsR
               },
             },
           },
-          ...defaultErrorResponses,
+          ...defaultOpenApiErrorResponses,
         },
       },
       options.openApiOverwrite?.get ?? {}
@@ -345,7 +345,7 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
               },
             },
           },
-          ...defaultErrorResponses,
+          ...defaultOpenApiErrorResponses,
         },
       },
       options.openApiOverwrite?.list ?? {}
@@ -397,7 +397,7 @@ export function createOpenApiMiddleware<T>(
               },
             },
           },
-          ...defaultErrorResponses,
+          ...defaultOpenApiErrorResponses,
         },
       },
       options.openApiOverwrite?.create ?? {}
@@ -449,7 +449,7 @@ export function patchOpenApiMiddleware<T>(
               },
             },
           },
-          ...defaultErrorResponses,
+          ...defaultOpenApiErrorResponses,
         },
       },
       options.openApiOverwrite?.update ?? {}
@@ -477,7 +477,7 @@ export function deleteOpenApiMiddleware<T>(
           204: {
             description: "Successful delete",
           },
-          ...defaultErrorResponses,
+          ...defaultOpenApiErrorResponses,
         },
       },
       options.openApiOverwrite?.delete ?? {}

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -92,7 +92,7 @@ describe("findExactlyOne", function () {
     ]);
   });
 
-  it("returns null with no matches.", async function () {
+  it("throws error with no matches.", async function () {
     const fn = () => (stuffModel as any).findExactlyOne({name: "OtherStuff"});
     await assert.isRejected(fn(), /Stuff\.findExactlyOne query returned no documents/);
   });

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import {model, Schema} from "mongoose";
 chai.use(chaiAsPromised);
 
-import {findOneOrThrow} from "./plugins";
+import {findExactlyOne, findOneOrThrow} from "./plugins";
 import {setupDb} from "./tests";
 
 interface Stuff {
@@ -18,6 +18,7 @@ const stuffSchema = new Schema<Stuff>({
 });
 
 stuffSchema.plugin(findOneOrThrow);
+stuffSchema.plugin(findExactlyOne);
 
 const stuffModel = model<Stuff>("Stuff", stuffSchema);
 
@@ -52,6 +53,73 @@ describe("findOneOrThrow", function () {
 
   it("throws error with two matches.", async function () {
     const fn = () => (stuffModel as any).findOneOrThrow({ownerId: "123"});
-    await assert.isRejected(fn(), "findOne query returned multiple documents");
+    await assert.isRejected(fn(), /Stuff\.findOne query returned multiple documents/);
+  });
+
+  it("throws custom error with two matches.", async function () {
+    const fn = () =>
+      (stuffModel as any).findOneOrThrow({ownerId: "123"}, {status: 400, title: "Oh no!"});
+
+    try {
+      await fn();
+      // If the promise doesn't reject, the test should fail
+      assert.fail("Expected promise to reject");
+    } catch (error: any) {
+      // Check if the error has title and status properties
+      assert.equal(error.title, "Oh no!");
+      assert.equal(error.status, 400);
+      assert.equal(error.detail, 'query: {"ownerId":"123"}');
+    }
+  });
+});
+
+describe("findExactlyOne", function () {
+  let things: any;
+
+  beforeEach(async function () {
+    await stuffModel.deleteMany({});
+    await setupDb();
+
+    [things] = await Promise.all([
+      stuffModel.create({
+        name: "Things",
+        ownerId: "123",
+      }),
+      stuffModel.create({
+        name: "StuffNThings",
+        ownerId: "123",
+      }),
+    ]);
+  });
+
+  it("returns null with no matches.", async function () {
+    const fn = () => (stuffModel as any).findExactlyOne({name: "OtherStuff"});
+    await assert.isRejected(fn(), /Stuff\.findExactlyOne query returned no documents/);
+  });
+
+  it("returns a single match", async function () {
+    const result = await (stuffModel as any).findExactlyOne({name: "Things"});
+    assert.equal(result._id.toString(), things._id.toString());
+  });
+
+  it("throws error with two matches.", async function () {
+    const fn = () => (stuffModel as any).findExactlyOne({ownerId: "123"});
+    await assert.isRejected(fn(), /Stuff\.findExactlyOne query returned multiple documents/);
+  });
+
+  it("throws custom error with two matches.", async function () {
+    const fn = () =>
+      (stuffModel as any).findExactlyOne({ownerId: "123"}, {status: 400, title: "Oh no!"});
+
+    try {
+      await fn();
+      // If the promise doesn't reject, the test should fail
+      assert.fail("Expected promise to reject");
+    } catch (error: any) {
+      // Check if the error has title and status properties
+      assert.equal(error.title, "Oh no!");
+      assert.equal(error.status, 400);
+      assert.equal(error.detail, 'query: {"ownerId":"123"}');
+    }
   });
 });

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -105,7 +105,7 @@ export function findExactlyOne<T>(schema: Schema) {
     const results = await this.find(query);
     if (results.length === 0) {
       throw new APIError({
-        status: 500,
+        status: 404,
         title: `${this.modelName}.findExactlyOne query returned no documents`,
         detail: `query: ${JSON.stringify(query)}`,
         ...errorArgs,

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -7,7 +7,7 @@ export interface BaseUser {
   email: string;
 }
 
-export function baseUserPlugin(schema: Schema) {
+export function baseUserPlugin(schema: Schema<any, any, any, any>) {
   schema.add({admin: {type: Boolean, default: false}});
   schema.add({email: {type: String, index: true}});
 }
@@ -18,7 +18,7 @@ export interface IsDeleted {
   deleted: boolean;
 }
 
-export function isDeletedPlugin(schema: Schema, defaultValue = false) {
+export function isDeletedPlugin(schema: Schema<any, any, any, any>, defaultValue = false) {
   schema.add({deleted: {type: Boolean, default: defaultValue, index: true}});
   schema.pre("find", function () {
     const query = this.getQuery();
@@ -33,7 +33,7 @@ export interface CreatedDeleted {
   created: {type: Date; required: true};
 }
 
-export function createdUpdatedPlugin(schema: Schema) {
+export function createdUpdatedPlugin(schema: Schema<any, any, any, any>) {
   schema.add({updated: {type: Date, index: true}});
   schema.add({created: {type: Date, index: true}});
 
@@ -68,7 +68,7 @@ export function firebaseJWTPlugin(schema: Schema) {
  * document, or throws an exception if multiple are found.
  * @param schema Mongoose Schema
  */
-export function findOneOrThrow<T>(schema: Schema) {
+export function findOneOrThrow<T>(schema: Schema<any, any, any, any>) {
   schema.statics.findOneOrThrow = async function (
     query: FilterQuery<T>,
     errorArgs?: Partial<APIErrorConstructor>
@@ -97,7 +97,7 @@ export function findOneOrThrow<T>(schema: Schema) {
  * multiple or none are found.
  * @param schema Mongoose Schema
  */
-export function findExactlyOne<T>(schema: Schema) {
+export function findExactlyOne<T>(schema: Schema<any, any, any, any>) {
   schema.statics.findExactlyOne = async function (
     query: FilterQuery<T>,
     errorArgs?: Partial<APIErrorConstructor>

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -51,7 +51,7 @@ export function createdUpdatedPlugin(schema: Schema<any, any, any, any>) {
     next();
   });
 
-  schema.pre("update", function (next) {
+  schema.pre(/save|updateOne|insertMany/, function (next) {
     this.updateOne({}, {$set: {updated: new Date()}});
     next();
   });

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -5,7 +5,9 @@ import supertest from "supertest";
 
 import {createdUpdatedPlugin} from "./plugins";
 
-mongoose.connect("mongodb://localhost:27017/ferns");
+mongoose.connect("mongodb://127.0.0.1/ferns?&connectTimeoutMS=360000").catch((e) => {
+  console.error("Error connecting to mongo", e);
+});
 
 export interface User {
   admin: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,6 +798,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mongodb-js/saslprep@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz#022fa36620a7287d17acd05c4aae1e5f390d250d"
+  integrity sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1802,10 +1809,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-bson@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-5.2.0.tgz#c81d35dd30e2798203e5422a639780ea98dd25ba"
-  integrity sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==
+bson@^5.5.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-5.5.1.tgz#f5849d405711a7f23acdda9a442375df858e6833"
+  integrity sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -4386,30 +4393,30 @@ mongodb-connection-string-url@^2.6.0:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.1.0.tgz#e551f9e496777bde9173e51d16c163ab2c805b9d"
-  integrity sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==
+mongodb@5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.9.0.tgz#5a22065fa8cfaf1d58bf2e3c451cd2c4bfa983a2"
+  integrity sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==
   dependencies:
-    bson "^5.0.1"
+    bson "^5.5.0"
     mongodb-connection-string-url "^2.6.0"
     socks "^2.7.1"
   optionalDependencies:
-    saslprep "^1.0.3"
+    "@mongodb-js/saslprep" "^1.1.0"
 
 mongoose-to-swagger@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mongoose-to-swagger/-/mongoose-to-swagger-1.4.0.tgz#30e8b9a9766277f8ec82dbcb69e424ed288168ef"
   integrity sha512-7O5f2bSVT7euXgMMhlxe4gz6sJW8E3GWHties2FR3B+W41yhW5dpG4RuC7rGL3tKi9nyDN/nkorkbs5v0AHLyg==
 
-mongoose@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.0.3.tgz#576375acb436f96cd3350fb63fddbac7ae51ff9c"
-  integrity sha512-3n8vc1/mssuxKa6vfghSocp3MeiCFYzhX36Ok+PsDNNYzHC9tw3rNkAMLemIwZ2jgXqkZ7CfKOxkzjp/d/SWfg==
+mongoose@^7.6.2:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.6.3.tgz#b06507dd164ad4426013eeb266d54aa1e5178092"
+  integrity sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==
   dependencies:
-    bson "^5.0.1"
+    bson "^5.5.0"
     kareem "2.5.1"
-    mongodb "5.1.0"
+    mongodb "5.9.0"
     mpath "0.9.0"
     mquery "5.0.0"
     ms "2.1.3"
@@ -5244,13 +5251,6 @@ safe-stable-stringify@^2.3.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-saslprep@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
-  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
-  dependencies:
-    sparse-bitfield "^3.0.3"
 
 scmp@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
I noticed this pattern a few times in my code and code review where we expect exactly one item to match. Add a plugin to clean up that code. Also allow setting the error params for both plugins so we can customize statuses and error messages.

Also export some more stuff for OpenAPI (had this hanging around on my branch, whoops). 