### PR TITLE
Add $in query to openapi param definition

### DIFF
--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -281,8 +281,8 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
                       },
                     },
                   },
-                }
-              ]
+                },
+              ],
             },
           });
         }

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -268,7 +268,22 @@ export function listOpenApiMiddleware<T>(model: Model<T>, options: Partial<Ferns
           params.push({
             name: field,
             in: "query",
-            schema: modelSwagger.properties[field],
+            schema: {
+              oneOf: [
+                modelSwagger.properties[field],
+                {
+                  type: "object",
+                  properties: {
+                    $in: {
+                      type: "array",
+                      items: {
+                        type: modelSwagger.properties[field]?.type,
+                      },
+                    },
+                  },
+                }
+              ]
+            },
           });
         }
 


### PR DESCRIPTION
This allows us to send $in queries from clients.