### PR TITLE
Allow dot notation updates

### DIFF
--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -195,6 +195,12 @@ exports[`openApi gets the openapi.json 1`] = `
                           },
                           "source": {
                             "properties": {
+                              "dateAdded": {
+                                "type": "string",
+                              },
+                              "href": {
+                                "type": "string",
+                              },
                               "name": {
                                 "type": "string",
                               },
@@ -658,6 +664,12 @@ exports[`openApi gets the openapi.json 1`] = `
                   },
                   "source": {
                     "properties": {
+                      "dateAdded": {
+                        "type": "string",
+                      },
+                      "href": {
+                        "type": "string",
+                      },
                       "name": {
                         "type": "string",
                       },
@@ -827,6 +839,12 @@ exports[`openApi gets the openapi.json 1`] = `
                     },
                     "source": {
                       "properties": {
+                        "dateAdded": {
+                          "type": "string",
+                        },
+                        "href": {
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
@@ -1573,6 +1591,12 @@ exports[`openApi gets the openapi.json 1`] = `
                     },
                     "source": {
                       "properties": {
+                        "dateAdded": {
+                          "type": "string",
+                        },
+                        "href": {
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
@@ -2029,6 +2053,12 @@ exports[`openApi gets the openapi.json 1`] = `
                   },
                   "source": {
                     "properties": {
+                      "dateAdded": {
+                        "type": "string",
+                      },
+                      "href": {
+                        "type": "string",
+                      },
                       "name": {
                         "type": "string",
                       },
@@ -2198,6 +2228,12 @@ exports[`openApi gets the openapi.json 1`] = `
                     },
                     "source": {
                       "properties": {
+                        "dateAdded": {
+                          "type": "string",
+                        },
+                        "href": {
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -858,18 +858,17 @@ describe("ferns-api", () => {
       // Allows updating a single field in a nested object
       const res = await agent
         .patch(`/food/${spinach._id}`)
-        .send({"source.href": "https://food.com", source: {name: "New Name"}})
+        .send({"source.href": "https://food.com"})
         .expect(200);
-      // Assert the field was updated with object notation.
-      assert.equal(res.body.data.source.name, "New Name");
       // Assert the field was updated with dot notation.
       assert.equal(res.body.data.source.href, "https://food.com");
-      // Assert this field hasn't changed.
+      // Assert these fields haven't changed.
+      assert.equal(res.body.data.source.name, "Brand");
       assert.equal(res.body.data.source.dateAdded, "2023-12-13T12:30:00.000Z");
 
       const dbSpinach = await FoodModel.findById(spinach._id);
-      assert.equal(dbSpinach?.source.name, "New Name");
       assert.equal(dbSpinach?.source.href, "https://food.com");
+      assert.equal(dbSpinach?.source.name, "Brand");
       assert.equal(dbSpinach?.source.dateAdded, "2023-12-13T12:30:00.000Z");
     });
   });

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -449,6 +449,8 @@ describe("ferns-api", () => {
           hidden: false,
           source: {
             name: "Brand",
+            href: "https://www.google.com",
+            dateAdded: "2023-12-13T12:30:00.000Z",
           },
           lastEatenWith: {
             dressing: "2021-12-03T19:00:30.000Z",
@@ -850,6 +852,25 @@ describe("ferns-api", () => {
         dressing: "2023-12-03T00:00:20.000Z",
         cucumber: "2023-12-04T12:00:20.000Z",
       });
+    });
+
+    it("update using dot notation", async function () {
+      // Allows updating a single field in a nested object
+      const res = await agent
+        .patch(`/food/${spinach._id}`)
+        .send({"source.href": "https://food.com", source: {name: "New Name"}})
+        .expect(200);
+      // Assert the field was updated with object notation.
+      assert.equal(res.body.data.source.name, "New Name");
+      // Assert the field was updated with dot notation.
+      assert.equal(res.body.data.source.href, "https://food.com");
+      // Assert this field hasn't changed.
+      assert.equal(res.body.data.source.dateAdded, "2023-12-13T12:30:00.000Z");
+
+      const dbSpinach = await FoodModel.findById(spinach._id);
+      assert.equal(dbSpinach?.source.name, "New Name");
+      assert.equal(dbSpinach?.source.href, "https://food.com");
+      assert.equal(dbSpinach?.source.dateAdded, "2023-12-13T12:30:00.000Z");
     });
   });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -660,7 +660,8 @@ export function fernsRouter<T>(
           // TODO: Send flattened dot notation body to preUpdate, then merge the returned body
           // with the original body, maintaining the dot notation. This way we don't have to write
           // two preUpdate branches downstream, one looking at the dot notation style and
-          // one looking at normal object style.   body = await options.preUpdate(body, req);
+          // one looking at normal object style.
+          body = await options.preUpdate(body, req);
         } catch (e: any) {
           if (isAPIError(e)) {
             throw e;

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -36,6 +36,8 @@ export interface Food {
   hidden?: boolean;
   source: {
     name: string;
+    href?: string;
+    dateAdded?: string;
   };
   tags: string[];
   eatenBy: [Schema.Types.ObjectId | User];
@@ -94,6 +96,8 @@ const foodSchema = new Schema<Food>(
     ownerId: {type: "ObjectId", ref: "User"},
     source: {
       name: String,
+      href: String,
+      dateAdded: String,
     },
     hidden: {type: Boolean, default: false},
     tags: [String],


### PR DESCRIPTION
This allows updating a single field in a nested document instead of needing to rewrite the entire doc.