### PR TITLE
Updates to sendToSlack

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ declare namespace NodeJS {
     SENTRY_DSN: string;
     SENTRY_TRACES_SAMPLE_RATE: string;
     SENTRY_PROFILES_SAMPLE_RATE: string;
-    SLACK_WEBHOOK: string;
+    SLACK_WEBHOOKS: string;
     SESSION_SECRET: string;
     TOKEN_ISSUER: string;
     TOKEN_EXPIRES_IN: string;


### PR DESCRIPTION
Slack changed the way you use webhooks and it is a 1-1 relationship webhook-channel now. So this way, we can pass in a basic object as the env variable to still support multiple channels.