### PR TITLE
Fix pre-save for createdUpdated

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -77,7 +77,7 @@ export function createdUpdatedPlugin(schema: Schema<any, any, any, any>) {
     next();
   });
 
-  schema.pre(/save|updateOne|insertMany/, function (next) {
+  schema.pre(/updateOne|insertMany/, function (next) {
     void this.updateOne({}, {$set: {updated: new Date()}});
     next();
   });


### PR DESCRIPTION
We were issuing unnecessary updateOne requests when calling .save(). We only need to do this for updateOne/insertMany because they skip the normal preSave hooks