### PR TITLE
Fix Sentry limit logger

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -571,8 +571,10 @@ export function fernsRouter<T>(
                 `without pagination, data may be silently truncated. req.query: ` +
                 `${JSON.stringify(req.query)}`;
               logger.warn(msg);
-              if (Sentry.isInitialized()) {
+              try {
                 Sentry.captureMessage(msg);
+              } catch (error) {
+                logger.error(`Error capturing message: ${error}`);
               }
             }
           }


### PR DESCRIPTION
## **User description**
TS suggested isInitialized was a real function, but that doesn't appear to be true.


___

## **Type**
bug_fix


___

## **Description**
- Wrapped the Sentry message capturing in a try-catch block to prevent unhandled errors.
- Added error logging within the catch block to ensure visibility of any issues during Sentry operations.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Improved Error Handling for Sentry Message Capturing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/api.ts

<li>Wrapped <code>Sentry.captureMessage</code> in a try-catch block to handle potential <br>errors.<br> <li> Added logging for errors caught when attempting to capture a message <br>with Sentry.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/377/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

