### PR TITLE
Use component to shrink OpenAPI.json

### DIFF
--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -325,7 +325,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Bad request",
@@ -336,7 +338,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -344,7 +348,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Document not found",
@@ -352,7 +358,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -740,7 +748,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Bad request",
@@ -751,7 +761,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -759,7 +771,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Document not found",
@@ -767,7 +781,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -797,7 +813,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Bad request",
@@ -808,7 +826,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -816,7 +836,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Document not found",
@@ -824,7 +846,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -1038,7 +1062,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Bad request",
@@ -1049,7 +1075,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -1057,7 +1085,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Document not found",
@@ -1065,7 +1095,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -1463,7 +1495,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Bad request",
@@ -1474,7 +1508,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -1482,7 +1518,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "Document not found",
@@ -1490,7 +1528,9 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": "#/components/schemas/APIError",
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
               },
             },
             "description": "The user is not allowed to perform this action on any document",

--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -2,6 +2,69 @@
 
 exports[`openApi gets the openapi.json 1`] = `
 {
+  "components": {
+    "schemas": {
+      "APIError": {
+        "properties": {
+          "code": {
+            "description": "An application-specific error code, expressed as a string value.",
+            "type": "string",
+          },
+          "detail": {
+            "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+            "type": "string",
+          },
+          "id": {
+            "description": "A unique identifier for this particular occurrence of the problem.",
+            "type": "string",
+          },
+          "links": {
+            "properties": {
+              "about": {
+                "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+                "type": "string",
+              },
+              "type": {
+                "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "meta": {
+            "description": "A meta object containing non-standard meta-information about the error.",
+            "type": "object",
+          },
+          "source": {
+            "properties": {
+              "header": {
+                "description": "A string indicating the name of a single request header which caused the error.",
+                "type": "string",
+              },
+              "parameter": {
+                "description": "A string indicating which URI query parameter caused the error.",
+                "type": "string",
+              },
+              "pointer": {
+                "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "status": {
+            "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+            "type": "number",
+          },
+          "title": {
+            "description": "The error message",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+  },
   "info": {
     "description": "Generated docs from an Express api",
     "title": "Express Application",
@@ -262,65 +325,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Bad request",
@@ -331,65 +336,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -397,65 +344,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Document not found",
@@ -463,65 +352,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -909,65 +740,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Bad request",
@@ -978,65 +751,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -1044,65 +759,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Document not found",
@@ -1110,65 +767,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -1198,65 +797,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Bad request",
@@ -1267,65 +808,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -1333,65 +816,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Document not found",
@@ -1399,65 +824,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -1671,65 +1038,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Bad request",
@@ -1740,65 +1049,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -1806,65 +1057,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Document not found",
@@ -1872,65 +1065,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on any document",
@@ -2328,65 +1463,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "400": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Bad request",
@@ -2397,65 +1474,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "403": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on this document",
@@ -2463,65 +1482,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "404": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "Document not found",
@@ -2529,65 +1490,7 @@ exports[`openApi gets the openapi.json 1`] = `
           "405": {
             "content": {
               "application/json": {
-                "schema": {
-                  "properties": {
-                    "code": {
-                      "description": "An application-specific error code, expressed as a string value.",
-                      "type": "string",
-                    },
-                    "detail": {
-                      "description": "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-                      "type": "string",
-                    },
-                    "id": {
-                      "description": "A unique identifier for this particular occurrence of the problem.",
-                      "type": "string",
-                    },
-                    "links": {
-                      "properties": {
-                        "about": {
-                          "description": "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-                          "type": "string",
-                        },
-                        "type": {
-                          "description": "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "meta": {
-                      "description": "A meta object containing non-standard meta-information about the error.",
-                      "type": "object",
-                    },
-                    "source": {
-                      "properties": {
-                        "header": {
-                          "description": "A string indicating the name of a single request header which caused the error.",
-                          "type": "string",
-                        },
-                        "parameter": {
-                          "description": "A string indicating which URI query parameter caused the error.",
-                          "type": "string",
-                        },
-                        "pointer": {
-                          "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].",
-                          "type": "string",
-                        },
-                      },
-                      "type": "object",
-                    },
-                    "status": {
-                      "description": "The HTTP status code applicable to this problem, expressed as a string value.",
-                      "type": "number",
-                    },
-                    "title": {
-                      "description": "The error message",
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
+                "schema": "#/components/schemas/APIError",
               },
             },
             "description": "The user is not allowed to perform this action on any document",

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -15,7 +15,7 @@ const m2sOptions = {
 
 export const apiErrorContent = {
   "application/json": {
-    schema: "#/components/schemas/APIError",
+    schema: {$ref: "#/components/schemas/APIError"},
   },
 };
 
@@ -118,6 +118,7 @@ export function convertModel(
 
 // We repeat this constantly, so we make it a component so we only have to define it once.
 function createAPIErrorComponent(openApi: any) {
+  // Create a schema component called APIError
   openApi?.component("schemas", "APIError", {
     type: "object",
     properties: {

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -15,71 +15,7 @@ const m2sOptions = {
 
 export const apiErrorContent = {
   "application/json": {
-    schema: {
-      type: "object",
-      properties: {
-        title: {
-          type: "string",
-          description: "The error message",
-        },
-        status: {
-          type: "number",
-          description:
-            "The HTTP status code applicable to this problem, expressed as a string value.",
-        },
-        id: {
-          type: "string",
-          description: "A unique identifier for this particular occurrence of the problem.",
-        },
-        links: {
-          type: "object",
-          properties: {
-            about: {
-              type: "string",
-              description:
-                "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
-            },
-            type: {
-              type: "string",
-              description:
-                "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
-            },
-          },
-        },
-        code: {
-          type: "string",
-          description: "An application-specific error code, expressed as a string value.",
-        },
-        detail: {
-          type: "string",
-          description:
-            "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
-        },
-        source: {
-          type: "object",
-          properties: {
-            pointer: {
-              type: "string",
-              description:
-                'A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].',
-            },
-            parameter: {
-              type: "string",
-              description: "A string indicating which URI query parameter caused the error.",
-            },
-            header: {
-              type: "string",
-              description:
-                "A string indicating the name of a single request header which caused the error.",
-            },
-          },
-        },
-        meta: {
-          type: "object",
-          description: "A meta object containing non-standard meta-information about the error.",
-        },
-      },
-    },
+    schema: "#/components/schemas/APIError",
   },
 };
 
@@ -180,7 +116,77 @@ export function convertModel(
   };
 }
 
+// We repeat this constantly, so we make it a component so we only have to define it once.
+function createAPIErrorComponent(openApi: any) {
+  openApi?.component("schemas", "APIError", {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: "The error message",
+      },
+      status: {
+        type: "number",
+        description:
+          "The HTTP status code applicable to this problem, expressed as a string value.",
+      },
+      id: {
+        type: "string",
+        description: "A unique identifier for this particular occurrence of the problem.",
+      },
+      links: {
+        type: "object",
+        properties: {
+          about: {
+            type: "string",
+            description:
+              "A link that leads to further details about this particular occurrence of the problem. When derefenced, this URI SHOULD return a human-readable description of the error.",
+          },
+          type: {
+            type: "string",
+            description:
+              "A link that identifies the type of error that this particular error is an instance of. This URI SHOULD be dereferencable to a human-readable explanation of the general error.",
+          },
+        },
+      },
+      code: {
+        type: "string",
+        description: "An application-specific error code, expressed as a string value.",
+      },
+      detail: {
+        type: "string",
+        description:
+          "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",
+      },
+      source: {
+        type: "object",
+        properties: {
+          pointer: {
+            type: "string",
+            description:
+              'A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].',
+          },
+          parameter: {
+            type: "string",
+            description: "A string indicating which URI query parameter caused the error.",
+          },
+          header: {
+            type: "string",
+            description:
+              "A string indicating the name of a single request header which caused the error.",
+          },
+        },
+      },
+      meta: {
+        type: "object",
+        description: "A meta object containing non-standard meta-information about the error.",
+      },
+    },
+  });
+}
+
 export function getOpenApiMiddleware<T>(model: Model<T>, options: Partial<FernsRouterOptions<T>>) {
+  createAPIErrorComponent(options.openApi);
   if (!options.openApi?.path) {
     // Just log this once rather than for each middleware.
     logger.debug("No options.openApi provided, skipping *OpenApiMiddleware");


### PR DESCRIPTION
## **User description**
Cuts the OpenAPI.json almost in half. Note the snapshot changes for how much this fixes it...

___

## **Type**
enhancement


___

## **Description**
- Introduced a reusable component for the API error schema to reduce redundancy and improve maintainability.
- Created a new function `createAPIErrorComponent` that encapsulates the detailed API error schema, making it easier to manage and update.
- Updated the `apiErrorContent` to reference the newly created APIError component, streamlining the OpenAPI.json structure.
- Integrated the creation of the APIError component into the OpenAPI middleware setup, ensuring it is available application-wide.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openApi.ts</strong><dd><code>Refactor API Error Schema into Reusable Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/openApi.ts

<li>Refactored the API error schema into a reusable component.<br> <li> Added <code>createAPIErrorComponent</code> function to define the APIError schema <br>once and reuse it across the application.<br> <li> Modified <code>apiErrorContent</code> to reference the new APIError component <br>schema.<br> <li> Ensured the new component is created as part of the OpenAPI middleware <br>setup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/379/files#diff-0ce4a2be85bf96c460fd66fde2150a409d598cc3b63ed83d03ffc7ee6321e67e">+71/-65</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

