### PR TITLE
update send to slack function

### DIFF
--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -363,13 +363,10 @@ export async function sendToSlack(text: string, slackChannel?: string, shouldThr
   }
   const slackWebhooks = JSON.parse(slackWebhooksString ?? "{}");
 
-  // use "default" channel if no slackChannel is provided
   const channel = slackChannel ?? "default";
 
-  // if the url for channel is not found, use "default" channel as key
   const slackWebhookUrl = slackWebhooks[channel] ?? slackWebhooks.default;
 
-  // if no channel or default channel is found, capture error and return
   if (!slackWebhookUrl) {
     Sentry.captureException(
       new Error(`No webhook url set in env for ${channel}. Slack message not sent`)
@@ -384,7 +381,6 @@ export async function sendToSlack(text: string, slackChannel?: string, shouldThr
     });
   } catch (error: any) {
     logger.error(`Error posting to slack: ${error.text ?? error.message}`);
-    // capture error if send to slack fails
     Sentry.captureException(error);
     if (shouldThrow) {
       throw new APIError({

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -363,19 +363,20 @@ export async function sendToSlack(text: string, slackChannel?: string, shouldThr
   }
   const slackWebhooks = JSON.parse(slackWebhooksString ?? "{}");
 
-    // use "default" channel if no slackChannel is provided
-    const channel = slackChannel ?? "default";
+  // use "default" channel if no slackChannel is provided
+  const channel = slackChannel ?? "default";
 
   // if the url for channel is not found, use "default" channel as key
-  const slackWebhookUrl = slackWebhooks[channel] ?? slackWebhooks["default"];
+  const slackWebhookUrl = slackWebhooks[channel] ?? slackWebhooks.default;
 
   // if no channel or default channel is found, capture error and return
-    if (!slackWebhookUrl) {
-    Sentry.captureException(new Error(`No webhook url set in env for ${channel}. Slack message not sent`));
+  if (!slackWebhookUrl) {
+    Sentry.captureException(
+      new Error(`No webhook url set in env for ${channel}. Slack message not sent`)
+    );
     logger.debug(`No webhook url set in env for ${channel}.`);
     return;
   }
-
 
   try {
     await axios.post(slackWebhookUrl, {

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -362,14 +362,29 @@ export async function sendToSlack(text: string, slackChannel?: string, shouldThr
     return;
   }
   const slackWebhooks = JSON.parse(slackWebhooksString ?? "{}");
-  // get the webhook url from the channel name as the key
-  const slackWebhookUrl = slackWebhooks[slackChannel ?? "default"];
+
+    // use "default" channel if no slackChannel is provided
+    const channel = slackChannel ?? "default";
+
+  // if the url for channel is not found, use "default" channel as key
+  const slackWebhookUrl = slackWebhooks[channel] ?? slackWebhooks["default"];
+
+  // if no channel or default channel is found, capture error and return
+    if (!slackWebhookUrl) {
+    Sentry.captureException(new Error(`No webhook url set in env for ${channel}. Slack message not sent`));
+    logger.debug(`No webhook url set in env for ${channel}.`);
+    return;
+  }
+
+
   try {
     await axios.post(slackWebhookUrl, {
       text,
     });
   } catch (error: any) {
     logger.error(`Error posting to slack: ${error.text ?? error.message}`);
+    // capture error if send to slack fails
+    Sentry.captureException(error);
     if (shouldThrow) {
       throw new APIError({
         status: 500,


### PR DESCRIPTION
### **User description**
Prevent silent failures when url not found


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved the `sendToSlack` function to use the "default" channel if the provided channel is not found.
- Added error capturing with Sentry when no webhook URL is set for the specified or default channel.
- Enhanced error handling by capturing exceptions when posting to Slack fails.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Improve error handling and fallback logic in `sendToSlack` function</code></dd></summary>
<hr>
      
src/expressServer.ts

<li>Added fallback to "default" channel if provided channel is not found.<br> <li> Added error capturing with Sentry when no webhook URL is set.<br> <li> Enhanced error handling by capturing exceptions when posting to Slack <br>fails.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/401/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+17/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

