### PR TITLE
Upgrade expo-server-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "axios": "^1.6.2",
     "cors": "^2.8.5",
     "cron": "^3.1.6",
-    "expo-server-sdk": "^3.6.0",
+    "expo-server-sdk": "^3.10.0",
     "express": "^4.17.1",
     "generaterr": "^1.5.0",
     "jsonwebtoken": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,10 +2962,10 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-server-sdk@^3.6.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/expo-server-sdk/-/expo-server-sdk-3.9.0.tgz#69ecd990e9ab7cdfeef84914edb4a5f1f170647f"
-  integrity sha512-7S24bGtGoyYfdJGzs4z8lKmDEzjSP+F/tCvhBycjW5rAEC2glYb9rUwvysV/9Gy2P2+zjJZCHahyYh6UJEY2mw==
+expo-server-sdk@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/expo-server-sdk/-/expo-server-sdk-3.10.0.tgz#ad4c475667b4f81dba39bd9fa837c4886658380c"
+  integrity sha512-isymUVz18Syp9G+TPs2MVZ6WdMoyLw8hDLhpywOd8JqM6iGTka6Dr8Dzq7mjGQ8C8486rxLawZx/W+ps+vkjLQ==
   dependencies:
     node-fetch "^2.6.0"
     promise-limit "^2.7.0"


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Upgraded `expo-server-sdk` dependency from version 3.6.0 to 3.10.0 in `package.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Upgrade `expo-server-sdk` dependency to version 3.10.0</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Upgraded <code>expo-server-sdk</code> dependency from version 3.6.0 to 3.10.0.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/411/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

