### PR TITLE
Add DateOnly schema type

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "generaterr": "^1.5.0",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
+    "luxon": "^3.5.0",
     "mongoose-to-swagger": "^1.4.0",
     "on-finished": "^2.3.0",
     "passport": "^0.7.0",

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -278,13 +278,6 @@ function initializeRoutes(
     res.end(`${res.sentry}\n`);
   });
 
-  logger.debug("Listening on routes:");
-  app._router.stack.forEach((r: any) => {
-    if (r.route && r.route.path) {
-      logger.debug(`[Route] ${r.route.path}`);
-    }
-  });
-
   return app;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,6 +4476,11 @@ lunr@^2.3.9:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
+luxon@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
+  integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
+
 luxon@~3.4.0:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.3.tgz#8ddf0358a9492267ffec6a13675fbaab5551315d"


### PR DESCRIPTION
### **User description**
Add a type that forces dates to end in 00:00:00.000Z UTC to match ferns-ui handling of date only fields.

Also remove the verbose but not very useful startup logging. It didn't include any of the FernsRouter routes and gets chatty with microservices and tests.


___

### **PR Type**
enhancement, tests, dependencies


___

### **Description**
- Introduced a new `DateOnly` schema type that normalizes dates to `00:00:00.000Z` using Luxon.
- Added tests for the `DateOnly` schema type to ensure proper date adjustment and error handling.
- Removed verbose startup logging from the express server to reduce noise.
- Updated `package.json` to include the `luxon` dependency for date handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Remove verbose startup logging in express server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/expressServer.ts

<li>Removed verbose startup logging.<br> <li> Simplified route initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/413/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plugins.ts</strong><dd><code>Introduce `DateOnly` schema type for date normalization</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/plugins.ts

<li>Introduced <code>DateOnly</code> schema type.<br> <li> Implemented date casting to <code>00:00:00.000Z</code> using Luxon.<br> <li> Registered <code>DateOnly</code> with Mongoose.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/413/files#diff-5d37292cf21755714262793e7553ee317a12b157d0601e27a0ca26e096a60c00">+51/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugins.test.ts</strong><dd><code>Add tests for `DateOnly` schema type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins.test.ts

<li>Added <code>DateOnly</code> schema type tests.<br> <li> Verified date adjustment to <code>00:00:00.000Z</code>.<br> <li> Tested invalid date handling.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/413/files#diff-80dedbdb2ef4dd17540ab73a859430da8c9ce7d17a11ccffa1ea73834c320a6e">+30/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add `luxon` dependency for date handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added `luxon` dependency.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/413/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

