### PR TITLE
Fh 9 fix pagination

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[typescript]": {
     "editor.codeActionsOnSave": {
-      "editor.organizeImports": true
+      "editor.organizeImports": "explicit"
     }
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -526,7 +526,7 @@ export function fernsRouter<T>(
 
       // Query param sort takes precedence over options.sort.
       if (req.query.sort) {
-        builtQuery = builtQuery.sort(req.query.sort as string);
+        builtQuery = builtQuery.sort(req.query.sort as MongooseSortValue);
       } else if (options.sort) {
         builtQuery = builtQuery.sort(options.sort);
       }
@@ -543,9 +543,6 @@ export function fernsRouter<T>(
         });
       }
 
-      // Uses metadata rather than counting the number of documents in the array for performance.
-      const total = await model.estimatedDocumentCount();
-
       let serialized;
 
       try {
@@ -560,6 +557,7 @@ export function fernsRouter<T>(
       let more;
       try {
         if (serialized && Array.isArray(serialized)) {
+          const total = serialized.length;
           more = serialized.length === limit + 1 && serialized.length > 0;
           if (more) {
             // Slice off the extra document we fetched to determine if more is true or not.
@@ -578,7 +576,13 @@ export function fernsRouter<T>(
               }
             }
           }
-          return res.json({data: serialized, more, page: req.query.page, limit, total});
+          return res.json({
+            data: serialized,
+            more,
+            page: req.query.page,
+            limit,
+            total,
+          });
         } else {
           return res.json({data: serialized});
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -526,7 +526,7 @@ export function fernsRouter<T>(
 
       // Query param sort takes precedence over options.sort.
       if (req.query.sort) {
-        builtQuery = builtQuery.sort(req.query.sort as MongooseSortValue);
+        builtQuery = builtQuery.sort(req.query.sort as string);
       } else if (options.sort) {
         builtQuery = builtQuery.sort(options.sort);
       }


### PR DESCRIPTION
### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Fixed pagination total calculation by using the length of serialized data instead of `estimatedDocumentCount`.
- Adjusted the response structure to include `total` in the JSON response.
- Updated VSCode settings to use "explicit" for `source.fixAll.eslint` and `editor.organizeImports`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Fix pagination total calculation and response structure</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/api.ts

<li>Removed <code>estimatedDocumentCount</code> for total calculation.<br> <li> Added total calculation based on serialized data length.<br> <li> Adjusted response structure to include <code>total</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/414/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Update VSCode settings for explicit ESLint and import organization</code></dd></summary>
<hr>

.vscode/settings.json

<li>Changed <code>source.fixAll.eslint</code> to "explicit".<br> <li> Changed <code>editor.organizeImports</code> to "explicit".<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/414/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

