### PR TITLE
Fix up querying for DateOnly field

### DIFF
--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -208,8 +208,20 @@ describe("DateOnly", function () {
     const res = await stuffModel.create({
       name: "Things",
       ownerId: "123",
-      date: "2005-10-10T17:17:17.017Z" as any,
+      date: "2005-10-10T17:17:17.017Z",
     });
     assert.strictEqual(res.date.toISOString(), "2005-10-10T00:00:00.000Z");
+  });
+
+  it("filter on date only", async function () {
+    await stuffModel.create({
+      name: "Things",
+      ownerId: "123",
+      date: "2000-10-10T17:17:17.017Z",
+    });
+    const found = await stuffModel.findOne({
+      date: {$gte: "2000-01-01T00:00:00.000Z", $lt: "2001-01-01T00:00:00.000Z"},
+    });
+    assert.strictEqual(found!.date.toISOString(), "2000-10-10T00:00:00.000Z");
   });
 });

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -219,8 +219,12 @@ describe("DateOnly", function () {
       ownerId: "123",
       date: "2000-10-10T17:17:17.017Z",
     });
-    const found = await stuffModel.findOne({
+    let found = await stuffModel.findOne({
       date: {$gte: "2000-01-01T00:00:00.000Z", $lt: "2001-01-01T00:00:00.000Z"},
+    });
+    assert.strictEqual(found!.date.toISOString(), "2000-10-10T00:00:00.000Z");
+    found = await stuffModel.findOne({
+      date: {$gte: "2000-01-01T12:12:12.000Z", $lt: "2001-01-01T12:12:12.000Z"},
     });
     assert.strictEqual(found!.date.toISOString(), "2000-10-10T00:00:00.000Z");
   });


### PR DESCRIPTION
### **User description**
Queries like $gte didn't work because they weren't being cast correctly.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `DateOnly` schema type to support query operators like $gte, $lte by implementing conditional handlers and casting logic.
- Improved error message in `auth.ts` for token refresh failures to provide more context.
- Added a test case in `plugins.test.ts` to verify filtering functionality on `DateOnly` fields using date range queries.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Enhance error message for token refresh failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/auth.ts

- Improved error message for token refresh failures.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/419/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plugins.ts</strong><dd><code>Enhance DateOnly schema type with query support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins.ts

<li>Implemented conditional handlers for DateOnly type.<br> <li> Added casting logic for query operators like $gte, $lte.<br> <li> Enhanced date casting to strip time portion.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/419/files#diff-5d37292cf21755714262793e7553ee317a12b157d0601e27a0ca26e096a60c00">+38/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugins.test.ts</strong><dd><code>Add test for DateOnly field filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins.test.ts

<li>Added test for filtering by DateOnly field.<br> <li> Ensured date filtering works with $gte and $lt operators.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/419/files#diff-80dedbdb2ef4dd17540ab73a859430da8c9ce7d17a11ccffa1ea73834c320a6e">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

