### PR TITLE
Auth changes and logging

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,9 +1,10 @@
 import {assert} from "chai";
 import express from "express";
 import supertest from "supertest";
+import TestAgent from "supertest/lib/agent";
 
 import {fernsRouter} from "./api";
-import {addAuthRoutes, setupAuth} from "./auth";
+import {addAuthRoutes, addMeRoutes, setupAuth} from "./auth";
 import {setupServer} from "./expressServer";
 import {Permissions} from "./permissions";
 import {Food, FoodModel, getBaseServer, setupDb, UserModel} from "./tests";
@@ -12,9 +13,9 @@ import {timeout} from "./utils";
 
 describe("auth tests", function () {
   let app: express.Application;
-  let server: any;
   let admin: any;
   let notAdmin: any;
+  let agent: TestAgent;
 
   beforeEach(async function () {
     jest.useFakeTimers({
@@ -45,8 +46,8 @@ describe("auth tests", function () {
       }),
     ]);
 
-    function addRoutes(): void {
-      app.use(
+    function addRoutes(router: express.Router): void {
+      router.use(
         "/food",
         fernsRouter(FoodModel, {
           permissions: {
@@ -76,11 +77,12 @@ describe("auth tests", function () {
         })
       );
     }
-    server = setupServer({
+    app = setupServer({
       userModel: UserModel as any,
       skipListen: true,
       addRoutes,
     });
+    agent = supertest.agent(app);
   });
 
   afterEach(async function () {
@@ -88,8 +90,7 @@ describe("auth tests", function () {
   });
 
   it("completes token signup e2e", async function () {
-    const agent = supertest.agent(app);
-    let res = await server
+    let res = await agent
       .post("/auth/signup")
       .send({email: "new@example.com", password: "123"})
       .expect(200);
@@ -99,7 +100,7 @@ describe("auth tests", function () {
     assert.isDefined(token);
     assert.isDefined(refreshToken);
 
-    res = await server
+    res = await agent
       .post("/auth/login")
       .send({email: "new@example.com", password: "123"})
       .expect(200);
@@ -127,7 +128,7 @@ describe("auth tests", function () {
     assert.isDefined(meRes.body.data.created);
     assert.isFalse(meRes.body.data.admin);
 
-    const mePatchRes = await server
+    const mePatchRes = await agent
       .patch("/auth/me")
       .send({email: "new2@example.com"})
       .set("authorization", `Bearer ${token}`)
@@ -154,7 +155,7 @@ describe("auth tests", function () {
   });
 
   it("signup with extra data", async function () {
-    const res = await server
+    const res = await agent
       .post("/auth/signup")
       .send({email: "new@example.com", password: "123", age: 25})
       .expect(200);
@@ -168,12 +169,12 @@ describe("auth tests", function () {
   });
 
   it("login failure", async function () {
-    let res = await server
+    let res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
     assert.deepEqual(res.body, {message: "Password or username is incorrect"});
-    res = await server
+    res = await agent
       .post("/auth/login")
       .send({email: "nope@example.com", password: "wrong"})
       .expect(401);
@@ -182,7 +183,6 @@ describe("auth tests", function () {
   });
 
   it("case insensitive email", async function () {
-    const agent = supertest.agent(app);
     const res = await agent
       .post("/auth/login")
       .send({email: "ADMIN@example.com", password: "securePassword"})
@@ -191,7 +191,6 @@ describe("auth tests", function () {
   });
 
   it("case insensitive email with emails with symbols", async function () {
-    const agent = supertest.agent(app);
     const res = await agent
       .post("/auth/login")
       .send({email: "ADMIN+other@example.com", password: "otherPassword"})
@@ -200,7 +199,6 @@ describe("auth tests", function () {
   });
 
   it("completes token login e2e", async function () {
-    const agent = supertest.agent(app);
     const res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "securePassword"})
@@ -239,7 +237,7 @@ describe("auth tests", function () {
     const food = getRes.body.data.find((f: any) => f.name === "Apple");
     assert.isDefined(food);
 
-    const updateRes = await server
+    const updateRes = await agent
       .patch(`/food/${food.id}`)
       .set("authorization", `Bearer ${token}`)
       .send({name: "Apple Pie"})
@@ -248,7 +246,6 @@ describe("auth tests", function () {
   });
 
   it("login successfully and tokens expire", async function () {
-    const agent = supertest.agent(app);
     const res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "securePassword"})
@@ -268,7 +265,7 @@ describe("auth tests", function () {
   });
 
   it("locks out after failed password attempts", async function () {
-    let res = await server
+    let res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
@@ -276,7 +273,7 @@ describe("auth tests", function () {
     assert.deepEqual(res.body, {message: "Password or username is incorrect"});
     let user = await UserModel.findById(admin._id);
     assert.equal((user as any)?.attempts, 1);
-    res = await server
+    res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
@@ -284,7 +281,7 @@ describe("auth tests", function () {
     assert.deepEqual(res.body, {message: "Password or username is incorrect"});
     user = await UserModel.findById(admin._id);
     assert.equal((user as any)?.attempts, 2);
-    res = await server
+    res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "wrong"})
       .expect(401);
@@ -294,7 +291,7 @@ describe("auth tests", function () {
     assert.equal((user as any)?.attempts, 3);
 
     // Logging in with correct password fails because account is locked
-    res = await server
+    res = await agent
       .post("/auth/login")
       .send({email: "admin@example.com", password: "securePassword"})
       .expect(401);
@@ -306,7 +303,6 @@ describe("auth tests", function () {
   });
 
   it("refresh token allows refresh of auth token", async function () {
-    const agent = supertest.agent(app);
     // initial login
     const initialLoginRes = await agent
       .post("/auth/login")
@@ -335,7 +331,6 @@ describe("auth tests", function () {
   });
 
   it("disabled user fails", async function () {
-    const agent = supertest.agent(app);
     // initial login
     const initialLoginRes = await agent
       .post("/auth/login")
@@ -356,12 +351,12 @@ describe("auth tests", function () {
   });
 
   it("signup user with email that is already registered", async function () {
-    await server
+    await agent
       .post("/auth/signup")
       .send({email: "new@example.com", password: "123", age: 25})
       .expect(200);
 
-    const res2 = await server
+    const res2 = await agent
       .post("/auth/signup")
       .send({email: "new@example.com", password: "456", age: 31})
       .expect(500);
@@ -405,7 +400,6 @@ describe("custom auth options", function () {
       }),
     ]);
     app = getBaseServer();
-    setupAuth(app, UserModel as any);
     addAuthRoutes(app, UserModel as any, {
       // custom refresh token logic based on admin or non admin
       generateTokenExpiration: (user?: {admin: boolean}) => {
@@ -416,6 +410,8 @@ describe("custom auth options", function () {
         }
       },
     });
+    setupAuth(app, UserModel as any);
+    addMeRoutes(app, UserModel as any);
     app.use(
       "/food",
       fernsRouter(FoodModel, {

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -45,7 +45,7 @@ describe("auth tests", function () {
       }),
     ]);
 
-    function addRoutes(router: express.Router, options: any): void {
+    function addRoutes(): void {
       app.use(
         "/food",
         fernsRouter(FoodModel, {

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -11,7 +11,7 @@ import passport from "passport";
 import qs from "qs";
 
 import {FernsRouterOptions} from "./api";
-import {addAuthRoutes, setupAuth, UserModel as UserMongooseModel} from "./auth";
+import {addAuthRoutes, addMeRoutes, setupAuth, UserModel as UserMongooseModel} from "./auth";
 import {APIError, apiErrorMiddleware, apiUnauthorizedMiddleware} from "./errors";
 import {logger, LoggingOptions, setupLogging} from "./logger";
 
@@ -229,6 +229,9 @@ function initializeRoutes(
 
   app.use(express.json());
 
+  // Add login/signup/refresh_token before the JWT/auth middlewares
+  addAuthRoutes(app, UserModel as any, options?.authOptions);
+
   setupAuth(app as any, UserModel as any);
 
   if (options.logRequests !== false) {
@@ -260,8 +263,7 @@ function initializeRoutes(
   app.use(oapi);
   app.use("/swagger", oapi.swaggerui());
 
-  addAuthRoutes(app as any, UserModel as any, options?.authOptions);
-
+  addMeRoutes(app, UserModel as any, options?.authOptions);
   addRoutes(app, {openApi: oapi});
 
   // The error handler must be before any other error middleware and after all controllers


### PR DESCRIPTION
### **User description**
Tracking down some weird auth issues. Move the /login, /signup, and /refresh_token routes outside of the JWT middleware. In a couple cases it was intercepting and giving a 401 before /refresh_token got a chance to do anything, and I've seen odd issues with /login getting 401s.

Add more logging to hopefully help track these issues in the future.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced JWT error logging by including user details and error specifics.
- Moved `/login`, `/signup`, and `/refresh_token` routes outside of JWT middleware to prevent premature 401 errors.
- Added `addMeRoutes` function to handle `/me` endpoint separately.
- Reordered middleware initialization to ensure auth routes are processed before JWT middleware.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Improve JWT error logging and route handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/auth.ts

<li>Added detailed logging for JWT token decoding errors.<br> <li> Introduced <code>addMeRoutes</code> function for handling <code>/me</code> endpoint.<br> <li> Moved <code>/auth</code> routes outside JWT middleware.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/420/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Reorder middleware and add `/me` route handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/expressServer.ts

<li>Added <code>addMeRoutes</code> to handle <code>/me</code> endpoint separately.<br> <li> Reordered middleware to place auth routes before JWT middleware.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/420/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

