### PR TITLE
Allow Authorization Secret in headers

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -213,6 +213,11 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
       return next();
     }
 
+    // Allow requests with a "Secret" prefix to pass through since this is a string value, not a jwt that needs to be decoded
+    if (req?.headers?.authorization?.split(" ")[0] === "Secret") {
+      return next();
+    }
+
     const token = customTokenExtractor(req);
 
     // For some reason, our app will happily put null into the authorization header when logging


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added functionality to allow requests with a "Secret" prefix in the authorization header to bypass JWT decoding.
- This change enables handling of non-JWT authorization tokens more effectively.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Support "Secret" prefix in authorization headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/auth.ts

<li>Added support for "Secret" prefix in authorization headers.<br> <li> Bypasses JWT decoding for requests with "Secret" prefix.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/456/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information