### PR TITLE
Add env preface option to sendToSlack

### DIFF
--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -408,7 +408,7 @@ export interface WrapScriptOptions {
 export async function wrapScript(func: () => Promise<any>, options: WrapScriptOptions = {}) {
   const name = require.main?.filename.split("/").slice(-1)[0].replace(".ts", "");
   logger.info(`Running script ${name}`);
-  await sendToSlack(`Running script ${name}`, options.slackChannel);
+  await sendToSlack(`Running script ${name}`, {slackChannel: options.slackChannel});
 
   if (options.terminateTimeout !== 0) {
     const warnTime = ((options.terminateTimeout ?? 300) / 2) * 1000;

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -349,7 +349,14 @@ export function cronjob(
 }
 
 // Convenience method to send data to a Slack webhook.
-export async function sendToSlack(text: string, slackChannel?: string, shouldThrow = false) {
+export async function sendToSlack(
+  text: string,
+  {
+    slackChannel,
+    shouldThrow = false,
+    env,
+  }: {slackChannel?: string; shouldThrow?: boolean; env?: string}
+) {
   // since Slack now requires a webhook for each channel, we need to store them in the environment
   // as an object, so we can look them up by channel name.
   const slackWebhooksString = process.env.SLACK_WEBHOOKS;
@@ -369,6 +376,10 @@ export async function sendToSlack(text: string, slackChannel?: string, shouldThr
     );
     logger.debug(`No webhook url set in env for ${channel}.`);
     return;
+  }
+
+  if (env) {
+    text = `[${env.toUpperCase()}] ${text}`;
   }
 
   try {

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -355,7 +355,7 @@ export async function sendToSlack(
     slackChannel,
     shouldThrow = false,
     env,
-  }: {slackChannel?: string; shouldThrow?: boolean; env?: string}
+  }: {slackChannel?: string; shouldThrow?: boolean; env?: string} = {}
 ) {
   // since Slack now requires a webhook for each channel, we need to store them in the environment
   // as an object, so we can look them up by channel name.


### PR DESCRIPTION
Also changed the optional stuff to an object so it is easy to add/remove from in the future. It'll be a breaking change, but easy to find/replace.

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `sendToSlack` function to include an optional `env` parameter.
- Prefixed Slack messages with the environment name when the `env` parameter is provided.
- Updated the function signature to accept parameters as an options object, improving flexibility.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Add environment preface option to Slack messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/expressServer.ts

<li>Added an <code>env</code> parameter to the <code>sendToSlack</code> function.<br> <li> Prefixed Slack messages with the environment name if provided.<br> <li> Updated function signature to use an options object.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/471/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information