### PR TITLE
Quiet down expected JWT warn message

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -226,7 +226,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
     } catch (error: any) {
       const userText = req.user?._id ? ` for user ${req.user._id} ` : "";
       const details = `[jwt] Error decoding token${userText}: ${error}, expired at ${error?.expiredAt}, current time: ${Date.now()}`;
-      logger.warn(details);
+      logger.debug(details);
       return res.status(401).json({message: error?.message, details});
     }
     if (decoded.id) {


### PR DESCRIPTION
### **User description**
JWTs expire and it is expected, we don't need to warn every time.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Changed JWT error logging level from `warn` to `debug`.

- Prevented unnecessary warnings for expected JWT expiration errors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Adjusted JWT error logging level to `debug`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/auth.ts

<li>Changed log level for JWT decoding errors from <code>warn</code> to <code>debug</code>.<br> <li> Improved log clarity for expected JWT expiration scenarios.


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/484/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>