### PR TITLE
Handle disableExternalErrorTracking better

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -116,6 +116,7 @@ export class APIError extends Error {
     this.detail = detail;
     this.source = source;
     this.meta = meta ?? {};
+    this.disableExternalErrorTracking = data.disableExternalErrorTracking;
     if (fields) {
       this.meta.fields = fields;
     }

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -274,7 +274,9 @@ function initializeRoutes(
 
   app.use(function onError(err: any, _req: any, res: any, _next: any) {
     logger.error(`Fallthrough error: ${err}${err?.stack ? `\n${err.stack}` : ""}}`);
-    Sentry.captureException(err);
+    if (!err.disableExternalErrorTracking) {
+      Sentry.captureException(err);
+    }
     res.statusCode = 500;
     res.end(`${res.sentry}\n`);
   });


### PR DESCRIPTION
### **User description**
I'm not sure this was actually ever working.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `disableExternalErrorTracking` property to `APIError` class.

- Updated error handling to respect `disableExternalErrorTracking` flag.

- Prevented external error tracking when the flag is enabled.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.ts</strong><dd><code>Add `disableExternalErrorTracking` to `APIError` class</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/errors.ts

<li>Added <code>disableExternalErrorTracking</code> property to <code>APIError</code> class.<br> <li> Ensured the property is initialized from input data.


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/496/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Respect `disableExternalErrorTracking` in error handling</code>&nbsp; </dd></summary>
<hr>

src/expressServer.ts

<li>Updated error handling middleware to check <br><code>disableExternalErrorTracking</code>.<br> <li> Prevented Sentry error reporting when the flag is enabled.


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/496/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>