### PR TITLE
Send disableExternalErrorTracking to frontend

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -163,7 +163,16 @@ export function isAPIError(error: Error): error is APIError {
 // There is almost certainly a more elegant solution to this.
 export function getAPIErrorBody(error: APIError): {[id: string]: any} {
   const errorData = {status: error.status, title: error.title};
-  for (const key of ["id", "links", "status", "code", "detail", "source", "meta"]) {
+  for (const key of [
+    "id",
+    "links",
+    "status",
+    "code",
+    "detail",
+    "source",
+    "meta",
+    "disableExternalErrorTracking",
+  ]) {
     if (error[key]) {
       errorData[key] = error[key];
     }


### PR DESCRIPTION
### **User description**
So the frontend can also not send to external error tracking.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `disableExternalErrorTracking` to the API error body.

- Ensures frontend can handle external error tracking flag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.ts</strong><dd><code>Include `disableExternalErrorTracking` in API error body</code>&nbsp; </dd></summary>
<hr>

src/errors.ts

<li>Added <code>disableExternalErrorTracking</code> to the list of keys processed in <br><code>getAPIErrorBody</code>.<br> <li> Ensures the key is included in the API error response if present.


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/507/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>