### PR TITLE
Redesign APIError to use standard Error params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 docs/
 log/
 *.log
+.env

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -297,7 +297,7 @@ describe("ferns-api", () => {
         .send({name: "Good Seller", show: false})
         .expect(400);
       assert.equal(
-        res.body.title,
+        res.body.name,
         "Malformed body, array operations should have a single, top level key, got: name,show"
       );
 
@@ -320,7 +320,7 @@ describe("ferns-api", () => {
         .patch(`/food/${apple._id}/categories/xyz`)
         .send({categories: {name: "Good Seller", show: false}})
         .expect(404);
-      assert.equal(res.body.title, "Could not find categories/xyz");
+      assert.equal(res.body.name, "Could not find categories/xyz");
       res = await agent
         .patch(`/food/${apple._id}/categories/${apple.categories[1]._id}`)
         .send({categories: {name: "Good Seller", show: false}})
@@ -331,7 +331,7 @@ describe("ferns-api", () => {
 
     it("delete array sub-schema item", async function () {
       let res = await agent.delete(`/food/${apple._id}/categories/xyz`).expect(404);
-      assert.equal(res.body.title, "Could not find categories/xyz");
+      assert.equal(res.body.name, "Could not find categories/xyz");
       res = await agent
         .delete(`/food/${apple._id}/categories/${apple.categories[0]._id}`)
         .expect(200);
@@ -353,7 +353,7 @@ describe("ferns-api", () => {
         .patch(`/food/${apple._id}/tags/xyz`)
         .send({tags: "unhealthy"})
         .expect(404);
-      assert.equal(res.body.title, "Could not find tags/xyz");
+      assert.equal(res.body.name, "Could not find tags/xyz");
       res = await agent
         .patch(`/food/${apple._id}/tags/healthy`)
         .send({tags: "unhealthy"})
@@ -363,7 +363,7 @@ describe("ferns-api", () => {
 
     it("delete array item", async function () {
       let res = await agent.delete(`/food/${apple._id}/tags/xyz`).expect(404);
-      assert.equal(res.body.title, "Could not find tags/xyz");
+      assert.equal(res.body.name, "Could not find tags/xyz");
       res = await agent.delete(`/food/${apple._id}/tags/healthy`).expect(200);
       assert.deepEqual(res.body.data.tags, ["cheap"]);
     });
@@ -523,12 +523,12 @@ describe("ferns-api", () => {
 
     it("list page 0 ", async function () {
       const res = await agent.get("/food?limit=1&page=0").expect(400);
-      assert.equal(res.body.title, "Invalid page: 0");
+      assert.equal(res.body.name, "Invalid page: 0");
     });
 
     it("list page with garbage ", async function () {
       const res = await agent.get("/food?limit=1&page=abc").expect(400);
-      assert.equal(res.body.title, "Invalid page: abc");
+      assert.equal(res.body.name, "Invalid page: abc");
     });
 
     it("list page over", async function () {
@@ -551,7 +551,7 @@ describe("ferns-api", () => {
     it("list query params not in list", async function () {
       // Should skip to carrots since apples are hidden
       const res = await agent.get(`/food?ownerId=${admin._id}`).expect(400);
-      assert.equal(res.body.title, "ownerId is not allowed as a query param.");
+      assert.equal(res.body.name, "ownerId is not allowed as a query param.");
     });
 
     it("list query by nested param", async function () {
@@ -764,17 +764,17 @@ describe("ferns-api", () => {
       let res = await agent
         .get(`/food?${qs.stringify({$and: [{ownerId: "healthy"}, {tags: "cheap"}]})}`)
         .expect(400);
-      assert.equal(res.body.title, "ownerId is not allowed as a query param.");
+      assert.equal(res.body.name, "ownerId is not allowed as a query param.");
       // Check in the other order
       res = await agent
         .get(`/food?${qs.stringify({$and: [{tags: "cheap"}, {ownerId: "healthy"}]})}`)
         .expect(400);
-      assert.equal(res.body.title, "ownerId is not allowed as a query param.");
+      assert.equal(res.body.name, "ownerId is not allowed as a query param.");
 
       res = await agent
         .get(`/food?${qs.stringify({$or: [{tags: "cheap"}, {ownerId: "healthy"}]})}`)
         .expect(400);
-      assert.equal(res.body.title, "ownerId is not allowed as a query param.");
+      assert.equal(res.body.name, "ownerId is not allowed as a query param.");
     });
 
     it("update", async function () {

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -347,7 +347,7 @@ describe("auth tests", function () {
     await admin.save();
 
     const failRes = await agent.get("/auth/me").expect(401);
-    assert.deepEqual(failRes.body, {title: "User is disabled", status: 401});
+    assert.deepEqual(failRes.body, {name: "User is disabled", status: 401});
   });
 
   it("signup user with email that is already registered", async function () {
@@ -362,7 +362,7 @@ describe("auth tests", function () {
       .expect(500);
 
     await timeout(1000);
-    assert.equal(res2.body.title, "A user with the given username is already registered");
+    assert.equal(res2.body.name, "A user with the given username is already registered");
   });
 });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -72,7 +72,7 @@ export async function signupUser(
     await user.save();
     return user;
   } catch (error: any) {
-    throw new APIError({title: error.message});
+    throw new APIError({...error});
   }
 }
 
@@ -253,7 +253,7 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
         req.user = await userModel.findById(decoded.id);
         if (req.user?.disabled) {
           logger.warn(`[jwt] User ${req.user.id} is disabled`);
-          return res.status(401).json({status: 401, title: "User is disabled"});
+          return res.status(401).json({status: 401, name: "User is disabled"});
         }
       } catch (error) {
         logger.warn(`[jwt] Error finding user from id: ${error}`);

--- a/src/example.ts
+++ b/src/example.ts
@@ -4,6 +4,7 @@ import passportLocalMongoose from "passport-local-mongoose";
 
 import {fernsRouter, FernsRouterOptions} from "./api";
 import {addAuthRoutes, setupAuth} from "./auth";
+import {APIError} from "./errors";
 import {setupServer} from "./expressServer";
 import {logger} from "./logger";
 import {Permissions} from "./permissions";
@@ -86,6 +87,18 @@ function getBaseServer() {
         },
       })
     );
+
+    // use this to test generating an APIError
+    router.use("/error", function () {
+      // const error = new Error("example test error contents");
+      console.debug("does this show up in sentry?");
+      throw new APIError({
+        name: "Test Error",
+        status: 500,
+        code: "test-error",
+        message: "This is a test error",
+      });
+    });
   }
 
   return setupServer({

--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -393,7 +393,8 @@ export async function sendToSlack(
     if (shouldThrow) {
       throw new APIError({
         status: 500,
-        title: `Error posting to slack: ${error.text ?? error.message}`,
+        name: "slackError",
+        message: `Error posting to slack`,
       });
     }
   }

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -80,7 +80,7 @@ function createAPIErrorComponent(openApi: any) {
         type: "string",
         description: "An application-specific error code, expressed as a string value.",
       },
-      detail: {
+      message: {
         type: "string",
         description:
           "A human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.",

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -126,7 +126,8 @@ export function permissionMiddleware<T>(
       } else {
         throw new APIError({
           status: 405,
-          title: `Method ${req.method} not allowed`,
+          name: "methodNotAllowedError",
+          message: `Method ${req.method} not allowed`,
         });
       }
 
@@ -136,7 +137,8 @@ export function permissionMiddleware<T>(
       if (!(await checkPermissions(method, options.permissions[method], req.user))) {
         throw new APIError({
           status: 405,
-          title:
+          name: "accessDeniedError",
+          message:
             `Access to ${method.toUpperCase()} on ${model.modelName} ` +
             `denied for ${req.user?.id}`,
         });
@@ -153,9 +155,9 @@ export function permissionMiddleware<T>(
         data = await populatedQuery.exec();
       } catch (error: any) {
         throw new APIError({
+          ...error,
           status: 500,
-          title: `GET failed on ${req.params.id}`,
-          error,
+          detail: `GET failed on ${req.params.id}`,
         });
       }
       if (!data || (["update", "delete"].includes(method) && data?.__t && !req.body?.__t)) {
@@ -163,7 +165,8 @@ export function permissionMiddleware<T>(
         if (["update", "delete"].includes(method) && data?.__t && !req.body?.__t) {
           throw new APIError({
             status: 404,
-            title: `Document ${req.params.id} not found for model ${model.modelName}`,
+            name: "documentNotFoundError",
+            message: `Document ${req.params.id} not found for model ${model.modelName}`,
           });
         }
 
@@ -176,7 +179,8 @@ export function permissionMiddleware<T>(
           Sentry.captureMessage(`Document ${req.params.id} not found for model ${model.modelName}`);
           const error = new APIError({
             status: 404,
-            title: `Document ${req.params.id} not found for model ${model.modelName}`,
+            name: "documentNotFoundError",
+            message: `Document ${req.params.id} not found for model ${model.modelName}`,
           });
           delete error.meta;
           throw error;
@@ -196,7 +200,8 @@ export function permissionMiddleware<T>(
           Sentry.captureMessage(`Document ${req.params.id} not found for model ${model.modelName}`);
           const error = new APIError({
             status: 404,
-            title: `Document ${req.params.id} not found for model ${model.modelName}`,
+            name: "documentNotFoundError",
+            message: `Document ${req.params.id} not found for model ${model.modelName}`,
           });
           delete error.meta;
           throw error;
@@ -206,7 +211,8 @@ export function permissionMiddleware<T>(
           );
           throw new APIError({
             status: 404,
-            title: `Document ${req.params.id} not found for model ${model.modelName}`,
+            name: "documentNotFoundError",
+            message: `Document ${req.params.id} not found for model ${model.modelName}`,
             meta: reason,
           });
         }
@@ -215,7 +221,8 @@ export function permissionMiddleware<T>(
       if (!(await checkPermissions(method, options.permissions[method], req.user, data))) {
         throw new APIError({
           status: 403,
-          title: `Access to GET on ${model.modelName}:${req.params.id} denied for ${req.user?.id}`,
+          name: "accessDeniedError",
+          message: `Access to GET on ${model.modelName}:${req.params.id} denied for ${req.user?.id}`,
         });
       }
 

--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -136,15 +136,15 @@ describe("findOneOrThrow", function () {
 
   it("throws custom error with two matches.", async function () {
     const fn = () =>
-      (StuffModel as any).findOneOrThrow({ownerId: "123"}, {status: 400, title: "Oh no!"});
+      (StuffModel as any).findOneOrThrow({ownerId: "123"}, {status: 400, name: "Oh no!"});
 
     try {
       await fn();
       // If the promise doesn't reject, the test should fail
       assert.fail("Expected promise to reject");
     } catch (error: any) {
-      // Check if the error has title and status properties
-      assert.equal(error.title, "Oh no!");
+      // Check if the error has name and status properties
+      assert.equal(error.name, "Oh no!");
       assert.equal(error.status, 400);
       assert.equal(error.detail, 'query: {"ownerId":"123"}');
     }
@@ -187,15 +187,15 @@ describe("findExactlyOne", function () {
 
   it("throws custom error with two matches.", async function () {
     const fn = () =>
-      (StuffModel as any).findExactlyOne({ownerId: "123"}, {status: 400, title: "Oh no!"});
+      (StuffModel as any).findExactlyOne({ownerId: "123"}, {status: 400, name: "Oh no!"});
 
     try {
       await fn();
       // If the promise doesn't reject, the test should fail
       assert.fail("Expected promise to reject");
     } catch (error: any) {
-      // Check if the error has title and status properties
-      assert.equal(error.title, "Oh no!");
+      // Check if the error has name and status properties
+      assert.equal(error.name, "Oh no!");
       assert.equal(error.status, 400);
       assert.equal(error.detail, 'query: {"ownerId":"123"}');
     }
@@ -267,14 +267,14 @@ describe("DateOnly", function () {
     it("returns 404 with context for hidden document", async () => {
       const doc = await StuffModel.create({name: "test", deleted: true});
       const res = await agent.get(`/stuff/${doc._id}`).expect(404);
-      assert.equal(res.body.title, `Document ${doc._id} not found for model Stuff`);
+      assert.equal(res.body.name, `Document ${doc._id} not found for model Stuff`);
       assert.deepEqual(res.body.meta, {deleted: "true"});
     });
 
     it("returns 404 without meta for missing document", async () => {
       const nonExistentId = "507f1f77bcf86cd799439011";
       const res = await agent.get(`/stuff/${nonExistentId}`).expect(404);
-      assert.equal(res.body.title, `Document ${nonExistentId} not found for model Stuff`);
+      assert.equal(res.body.name, `Document ${nonExistentId} not found for model Stuff`);
       assert.isUndefined(res.body.meta);
     });
   });

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -113,8 +113,8 @@ export function findOneOrThrow<T>(schema: Schema<any, any, any, any>) {
     } else if (results.length > 1) {
       throw new APIError({
         status: 500,
-        title: `${this.modelName}.findOne query returned multiple documents`,
-        detail: `query: ${JSON.stringify(query)}`,
+        name: `${this.modelName}.findOne query returned multiple documents`,
+        message: `query: ${JSON.stringify(query)}`,
         ...errorArgs,
       });
     } else {
@@ -140,15 +140,15 @@ export function findExactlyOne<T>(schema: Schema<any, any, any, any>) {
     if (results.length === 0) {
       throw new APIError({
         status: 404,
-        title: `${this.modelName}.findExactlyOne query returned no documents`,
-        detail: `query: ${JSON.stringify(query)}`,
+        name: `${this.modelName}.findExactlyOne query returned no documents`,
+        message: `query: ${JSON.stringify(query)}`,
         ...errorArgs,
       });
     } else if (results.length > 1) {
       throw new APIError({
         status: 500,
-        title: `${this.modelName}.findExactlyOne query returned multiple documents`,
-        detail: `query: ${JSON.stringify(query)}`,
+        name: `${this.modelName}.findExactlyOne query returned multiple documents`,
+        message: `query: ${JSON.stringify(query)}`,
         ...errorArgs,
       });
     } else {

--- a/src/populate.ts
+++ b/src/populate.ts
@@ -215,7 +215,11 @@ export function getOpenApiSpecForModel(
 // that the populatePath was added, we remove the population and just return the _id.
 export function unpopulate<T>(doc: Document<T>, path: string): Document<T> {
   if (!path) {
-    throw new APIError({status: 500, title: "path is required for unpopulate"});
+    throw new APIError({
+      status: 500,
+      name: "unpopulateError",
+      message: "path is required for unpopulate",
+    });
   }
   const pathParts = path.split(".");
 

--- a/src/transformers.test.ts
+++ b/src/transformers.test.ts
@@ -139,7 +139,7 @@ describe("query and transform", function () {
       .send({ownerId: notAdmin.id})
       .expect(403);
     assert.isTrue(
-      spinachRes.body.title.includes("User of type owner cannot write fields: ownerId")
+      spinachRes.body.name.includes("User of type owner cannot write fields: ownerId")
     );
   });
 
@@ -182,7 +182,7 @@ describe("query and transform", function () {
       .patch(`/food/${carrots.id}`)
       .send({created: "2020-01-01T00:00:00Z"})
       .expect(403);
-    assert.isTrue(writeRes.body.title.includes("User of type auth cannot write fields: created"));
+    assert.isTrue(writeRes.body.name.includes("User of type auth cannot write fields: created"));
   });
 
   it("anon read transform", async function () {

--- a/src/transformers.ts
+++ b/src/transformers.ts
@@ -164,9 +164,10 @@ export async function defaultResponseHandler<T>(
     return serialize(request, options, doc);
   } catch (error: any) {
     throw new APIError({
+      ...error,
       status: 400,
-      title: `Error serializing ${method} response: ${error.message}`,
-      error,
+      name: "SerializationError",
+      detail: `Error serializing ${method} response`,
     });
   }
 }


### PR DESCRIPTION
### **User description**
We were extending native `Error` for `APIError`, but then not using it with the standard fields. We added `title`, but ignored `name`, we added `details` but largely ignored `message`. This was breaking stuff that relies on the standard Error definition like Sentry. This will require a fair amount of refactoring, but I think it'll be worth it for the added context to error alerting.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Refactored `APIError` to align with standard `Error` parameters.
  - Replaced `title` with `name` and `message` for better compatibility.
  - Improved error handling consistency across the codebase.

- Updated test cases to validate changes in error structure.
  - Replaced assertions on `title` with `name` and `message`.

- Enhanced logging and error reporting mechanisms.
  - Added stack trace preservation and improved Sentry integration.

- Adjusted API schema and documentation to reflect error structure changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>api.test.ts</strong><dd><code>Updated test cases to validate new `APIError` structure</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-7859a5148ded19af212367ec9a3558864109c5515dea657bc8f11ee238765dc7">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth.test.ts</strong><dd><code>Adjusted auth tests for updated error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-7e878fd5df9f5b949227e866aa85dc4383321531d0fc22ee586b850509000f33">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugins.test.ts</strong><dd><code>Updated plugin tests to validate new error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-80dedbdb2ef4dd17540ab73a859430da8c9ce7d17a11ccffa1ea73834c320a6e">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transformers.test.ts</strong><dd><code>Adjusted transformer tests for updated error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-f1da0399729d5e3f3c82cfd9481157a36e9921a4d95ff97eabd870676430a304">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>api.ts</strong><dd><code>Refactored API logic to use updated `APIError` structure</code>&nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+100/-81</a></td>

</tr>

<tr>
  <td><strong>auth.ts</strong><dd><code>Updated auth logic to align with new `APIError` structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errors.ts</strong><dd><code>Redesigned `APIError` class to align with standard `Error` parameters</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0">+40/-47</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>example.ts</strong><dd><code>Added example route to test `APIError` changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-5d37297cbe5b4756da49c9b31a48bbd98dde814391111d02e58f6f6cb5c2aa1a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>expressServer.ts</strong><dd><code>Updated Slack error handling to use new `APIError` structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openApi.ts</strong><dd><code>Adjusted OpenAPI schema to reflect `APIError` changes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-0ce4a2be85bf96c460fd66fde2150a409d598cc3b63ed83d03ffc7ee6321e67e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissions.ts</strong><dd><code>Refactored permission middleware to use updated `APIError` structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-489c5229a411d478a9073847170556f5ca5980b8298d42fea3caff0c5f20b124">+16/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugins.ts</strong><dd><code>Refactored plugin error handling to align with new <code>APIError</code> structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-5d37292cf21755714262793e7553ee317a12b157d0601e27a0ca26e096a60c00">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>populate.ts</strong><dd><code>Updated `unpopulate` function to use new `APIError` structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-fe6875cb88f2efad3be804290e45138f69636fd6fc90eeae56768702cfce1484">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transformers.ts</strong><dd><code>Refactored transformer error handling to align with new <code>APIError</code> <br>structure</code></dd></td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/510/files#diff-07acca1d32f9803759359c1df74c772dc8d0adc30a5388460598f32acde4c754">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>