### PR TITLE
Fix bugs around array patches

### DIFF
--- a/src/__snapshots__/openApi.test.ts.snap
+++ b/src/__snapshots__/openApi.test.ts.snap
@@ -133,11 +133,19 @@ exports[`openApi gets the openapi.json 1`] = `
                                 "_id": {
                                   "type": "string",
                                 },
+                                "created": {
+                                  "format": "date-time",
+                                  "type": "string",
+                                },
                                 "name": {
                                   "type": "string",
                                 },
                                 "show": {
                                   "type": "boolean",
+                                },
+                                "updated": {
+                                  "format": "date-time",
+                                  "type": "string",
                                 },
                               },
                               "required": [],
@@ -416,11 +424,19 @@ exports[`openApi gets the openapi.json 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -628,11 +644,19 @@ exports[`openApi gets the openapi.json 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -970,11 +994,19 @@ exports[`openApi gets the openapi.json 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -1246,11 +1278,19 @@ exports[`openApi gets the openapi.json 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -1458,11 +1498,19 @@ exports[`openApi gets the openapi.json 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -1844,11 +1892,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                                 "_id": {
                                   "type": "string",
                                 },
+                                "created": {
+                                  "format": "date-time",
+                                  "type": "string",
+                                },
                                 "name": {
                                   "type": "string",
                                 },
                                 "show": {
                                   "type": "boolean",
+                                },
+                                "updated": {
+                                  "format": "date-time",
+                                  "type": "string",
                                 },
                               },
                               "required": [],
@@ -2127,11 +2183,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -2339,11 +2403,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -2681,11 +2753,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -2957,11 +3037,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -3169,11 +3257,19 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -3568,11 +3664,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                                 "_id": {
                                   "type": "string",
                                 },
+                                "created": {
+                                  "format": "date-time",
+                                  "type": "string",
+                                },
                                 "name": {
                                   "type": "string",
                                 },
                                 "show": {
                                   "type": "boolean",
+                                },
+                                "updated": {
+                                  "format": "date-time",
+                                  "type": "string",
                                 },
                               },
                               "required": [],
@@ -3757,11 +3861,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -3875,11 +3987,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -4123,11 +4243,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],
@@ -4305,11 +4433,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                         "_id": {
                           "type": "string",
                         },
+                        "created": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
                         "name": {
                           "type": "string",
                         },
                         "show": {
                           "type": "boolean",
+                        },
+                        "updated": {
+                          "format": "date-time",
+                          "type": "string",
                         },
                       },
                       "required": [],
@@ -4423,11 +4559,19 @@ exports[`openApi populate gets the openapi.json with populate 1`] = `
                           "_id": {
                             "type": "string",
                           },
+                          "created": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "name": {
                             "type": "string",
                           },
                           "show": {
                             "type": "boolean",
+                          },
+                          "updated": {
+                            "format": "date-time",
+                            "type": "string",
                           },
                         },
                         "required": [],

--- a/src/api.ts
+++ b/src/api.ts
@@ -860,7 +860,12 @@ export function fernsRouter<T>(
           status: 404,
         });
       }
-      if (operation === "PATCH") {
+      // For PATCHing an item by ID, we need to merge the objects so we don't override the _id or
+      // other parts of the subdocument.
+      if (operation === "PATCH" && isValidObjectId(req.params.itemId)) {
+        Object.assign(array[index], req.body[field]);
+      } else if (operation === "PATCH") {
+        // For PATCHing a string array, we can replace the whole object.
         array[index] = req.body[field];
       } else {
         array.splice(index, 1);

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -28,6 +28,8 @@ export interface FoodCategory {
   _id?: string;
   name: string;
   show: boolean;
+  created: Date;
+  updated: Date;
 }
 
 export interface Food {
@@ -87,10 +89,13 @@ const staffUserSchema = new Schema<StaffUser>({
 });
 export const StaffUserModel = UserModel.discriminator("Staff", staffUserSchema);
 
-const foodCategorySchema = new Schema<FoodCategory>({
-  name: String,
-  show: Boolean,
-});
+const foodCategorySchema = new Schema<FoodCategory>(
+  {
+    name: String,
+    show: Boolean,
+  },
+  {timestamps: {updatedAt: "updated", createdAt: "created"}}
+);
 
 const likesSchema = new Schema<any>({
   userId: {type: "ObjectId", ref: "User"},


### PR DESCRIPTION
### **User description**
The old way was deleting the object at the path, then recreating it. So _id changed, created timestamps were updated, and updated timestamp was always the same as created. It also overwrote missing fields, unlike PATCH to the rest of the document.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fix PATCH handling for array subdocuments to merge instead of replace
  - Prevents loss of _id and timestamps on update
  - Ensures only specified fields are updated, not overwritten

- Add test to verify timestamp updates on array subdocuments

- Enhance schema to track created and updated timestamps for categories


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Refine PATCH logic for array subdocuments to merge updates</code></dd></summary>
<hr>

src/api.ts

<li>Changed PATCH logic for array subdocuments to merge updates instead of <br>replacing objects<br> <li> Ensures _id and timestamps are preserved during PATCH<br> <li> Distinguishes between object and string array PATCH operations


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/524/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.test.ts</strong><dd><code>Add test for array subdocument timestamp updates on PATCH</code></dd></summary>
<hr>

src/api.test.ts

<li>Added test to verify timestamp updates on array subdocuments after <br>PATCH<br> <li> Ensures only the updated subdocument's timestamp changes<br> <li> Confirms other fields remain unchanged


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/524/files#diff-7859a5148ded19af212367ec9a3558864109c5515dea657bc8f11ee238765dc7">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.ts</strong><dd><code>Add timestamps to FoodCategory schema and interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests.ts

<li>Added created and updated timestamp fields to FoodCategory interface<br> <li> Updated foodCategorySchema to use Mongoose timestamps for <br>created/updated


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/524/files#diff-95ae21795705607737de752c4afbc844945fd82c4fac042009363b886ed156d4">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>