### PR TITLE
Add OpenAPI ETag

### DIFF
--- a/src/expressServer.ts
+++ b/src/expressServer.ts
@@ -14,6 +14,7 @@ import {FernsRouterOptions} from "./api";
 import {addAuthRoutes, addMeRoutes, setupAuth, UserModel as UserMongooseModel} from "./auth";
 import {APIError, apiErrorMiddleware, apiUnauthorizedMiddleware} from "./errors";
 import {logger, LoggingOptions, setupLogging} from "./logger";
+import {openApiEtagMiddleware} from "./openApiEtag";
 
 const SLOW_READ_MAX = 200;
 const SLOW_WRITE_MAX = 500;
@@ -220,6 +221,9 @@ function initializeRoutes(
     }
     next();
   });
+
+  // Add ETag middleware for OpenAPI JSON endpoint before the openapi middleware
+  app.use(openApiEtagMiddleware);
 
   const oapi = openapi({
     openapi: "3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./auth";
 export * from "./errors";
 export * from "./expressServer";
 export * from "./logger";
+export * from "./openApiEtag";
 export * from "./permissions";
 export * from "./plugins";
 export * from "./populate";

--- a/src/openApiEtag.ts
+++ b/src/openApiEtag.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+import {NextFunction, Request, Response} from "express";
+
+/**
+ * Middleware to add ETag support for OpenAPI JSON endpoint.
+ * This middleware should be added before the @wesleytodd/openapi middleware
+ * to intercept requests to /openapi.json and add conditional request support.
+ */
+export function openApiEtagMiddleware(req: Request, res: Response, next: NextFunction): void {
+  // Only handle GET requests to /openapi.json
+  if (req.method !== "GET" || req.path !== "/openapi.json") {
+    return next();
+  }
+
+  // Store original res.json to intercept the response
+  const originalJson = res.json.bind(res);
+
+  res.json = function (body: any) {
+    // Generate ETag based on the JSON content
+    const jsonString = JSON.stringify(body);
+    const etag = `"${crypto.createHash("sha256").update(jsonString).digest("hex").substring(0, 16)}"`;
+
+    // Set ETag header
+    res.set("ETag", etag);
+
+    // Check If-None-Match header for conditional requests
+    const ifNoneMatch = req.get("If-None-Match");
+    if (ifNoneMatch === etag) {
+      // Resource hasn't changed, return 304 Not Modified
+      res.status(304).end();
+      return res;
+    }
+
+    // Resource has changed or no conditional header, return the content
+    return originalJson(body);
+  };
+
+  next();
+}


### PR DESCRIPTION
### **User description**
This file winds up getting fetched a lot. It's a big file that doesn't change all that often. Use ETags to allow the client to use a cached version.

To test, build it, copy it into flourish backend's node_modules, start the backend, and log in with the app. Observe the first time you get a 200 and download openapi.json. When refreshing you get a 304 and don't download the file.
___

### **PR Type**
Enhancement


___

### **Description**
- Add ETag middleware for OpenAPI JSON endpoint caching

- Implement conditional requests with If-None-Match header support

- Generate SHA256-based ETags for response validation

- Add comprehensive test coverage for ETag functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Request"] --> B["ETag Middleware"]
  B --> C["Check If-None-Match"]
  C --> D["ETag Match?"]
  D -->|Yes| E["Return 304"]
  D -->|No| F["Generate New ETag"]
  F --> G["Return 200 + Content"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openApiEtag.ts</strong><dd><code>Implement OpenAPI ETag middleware functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openApiEtag.ts

<ul><li>Create new middleware for OpenAPI endpoint ETag support<br> <li> Generate SHA256-based ETags from JSON content<br> <li> Handle conditional requests with If-None-Match header<br> <li> Return 304 status for unchanged resources</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/552/files#diff-4b63376a630cb71c1db08462c06dd5d2fd139d93f42ebc1f6506733ebf1fb14f">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>expressServer.ts</strong><dd><code>Register ETag middleware in Express server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/expressServer.ts

<ul><li>Import and register <code>openApiEtagMiddleware</code><br> <li> Add middleware before OpenAPI middleware in request pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/552/files#diff-d8c51792951866599be44999fb26695bc96b6b7435d64cab68e024b90efdeb1c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export OpenAPI ETag module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

- Export `openApiEtag` module for external usage


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/552/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openApi.test.ts</strong><dd><code>Add comprehensive ETag functionality tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openApi.test.ts

<ul><li>Add test for ETag header presence and format<br> <li> Test 304 response for matching If-None-Match header<br> <li> Test 200 response for non-matching If-None-Match header</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-api/pull/552/files#diff-0f6611359ad99d278204dbacfe1380fedb1cea6f1f661d4f7238b4c186aaa5f4">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

